### PR TITLE
Proposed fix for SOCIAL-267: convert unknown privacy to 'custom'

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AlbumMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AlbumMixin.java
@@ -69,7 +69,11 @@ abstract class AlbumMixin {
 		@Override
 		public Privacy deserialize(JsonParser jp, DeserializationContext ctxt)
 				throws IOException, JsonProcessingException {
-			return Privacy.valueOf(jp.getText().replace("-", "_").toUpperCase());
+			try {
+				return Privacy.valueOf(jp.getText().replace("-", "_").toUpperCase());
+			} catch (IllegalArgumentException e) {
+				return Privacy.CUSTOM;
+			}
 		}
 	}
 }

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
@@ -89,6 +89,16 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 		assertSingleAlbum(album);
 	}
 
+	@Test
+	public void getAlbumWithUnknownPrivacy() {
+		mockServer.expect(requestTo("https://graph.facebook.com/10151447271460580"))
+			.andExpect(method(GET))
+			.andExpect(header("Authorization", "OAuth someAccessToken"))
+			.andRespond(withResponse(jsonResource("testdata/album-with-unknown-privacy"), responseHeaders));
+		Album album = facebook.mediaOperations().getAlbum("10151447271460580");
+		assertSingleAlbum(album);
+	}
+
 	@Test(expected = NotAuthorizedException.class)
 	public void getAlbum_unauthorized() {
 		unauthorizedFacebook.mediaOperations().getAlbum("192837465");

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/testdata/album-with-unknown-privacy.json
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/testdata/album-with-unknown-privacy.json
@@ -1,0 +1,17 @@
+{
+    "id":"10151447271460580",
+    "from":
+    {
+        "name":"Craig Walls",
+        "id":"738140579"
+    },
+    "name":"Early Broncos",
+    "location":"Somewhere",
+    "link":"http:\/\/www.facebook.com\/album.php?aid=620722&id=738140579",
+    "cover_photo":"10151447371355580",
+    "privacy":"networks",
+    "count":1,
+    "type":"normal",
+    "created_time":"2011-03-24T21:36:04+0000",
+    "updated_time":"2011-03-24T22:00:12+0000"
+}


### PR DESCRIPTION
- update AlbumMixin to return Privacy.CUSTOM for any conversion errors
  when deserializing privacy
- add new test data for album with privacy set to 'network', as indicated
  in JIRA issue
- add new test case 'getAlbumWithUnknownPrivacy' to MediaTemplateTest that
  uses this data
