### PR TITLE
Updated Facebook's connection support to reflect recent changes in Spring Social Core

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
@@ -36,6 +36,7 @@ public class FacebookOAuth2Template extends OAuth2Template {
 
 	public FacebookOAuth2Template(String clientId, String clientSecret) {
 		super(clientId, clientSecret, "https://www.facebook.com/dialog/oauth", "https://graph.facebook.com/oauth/access_token");
+		setUseParametersForClientAuthentication(true);
 	}
 
 	@Override


### PR DESCRIPTION
Specifically, FacebookOAuth2Template's constructor now calls setUseParametersForClientAuthentication(true) since Facebook does not (yet) support HTTP Basic client authentication as required by the latest drafts of the OAuth2 spec.
