### PR TITLE
Fixed reference to a local resource.

### DIFF
--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.MediaType;
 import org.springframework.social.NotAuthorizedException;
+import org.springframework.test.web.client.ResponseCreators;
 
 /**
  * @author Craig Walls
@@ -37,7 +38,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 		mockServer.expect(requestTo("https://graph.facebook.com/123456/comments?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
-			.andRespond(withSuccess(new FileSystemResource("/Users/habuma/foo.json"), MediaType.APPLICATION_JSON));
+			.andRespond(withSuccess(jsonResource("testdata/comments"), MediaType.APPLICATION_JSON));
 		
 		List<Comment> comments = facebook.commentOperations().getComments("123456");
 		assertEquals(2, comments.size());


### PR DESCRIPTION
I had a temporary experimental reference to a local resource in one of the test cases, but forgot to remove it before the last commit. Fixed.
