### PR TITLE
Add postNotification method to userOperations

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
@@ -90,4 +90,23 @@ public interface UserOperations {
 	 * @throws MissingAuthorizationException if FacebookTemplate was not created with an access token.
 	 */
 	List<Reference> search(String query);
+	
+	/**
+	 * Posts a short free-form message to the user's notification list 
+	 * NOTE: This will only work with an APP access token (not a user access token)
+	 * SEE: https://developers.facebook.com/docs/app_notifications/
+	 * 
+	 * @param userId the Facebook user ID
+	 * @param href The relative path/GET params of the target (for example, "index.html?gift_id=123", 
+	 * or "?gift_id=123"). Then we will construct proper target URL based on your app settings. The 
+	 * logic is that, on web, if Canvas setting exists, we always show “Canvas URL + href”. If not, 
+	 * we show nothing. In the future (not in this version), we will also use existing URL 
+	 * re-writing logic to support mobile canvas and native mobile apps. We also append some special 
+	 * tracking params (fb_source, notif_id, notif_t) to the target URL for developers to track at
+	 *  their side. One example of target URL displayed in the jewel is: 
+	 *  https://apps.facebook.com/bzhang_og/?fb_source=notification&notif_id=notif_514699839_145756436&ref=notif&notif_t=app_notification
+	 * @param template The customized text of the notification.
+	 * @return
+	 */
+	boolean postNotifcation(String userId, String href, String template);
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
@@ -18,6 +18,7 @@ package org.springframework.social.facebook.api.impl;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.codehaus.jackson.JsonNode;
 import org.springframework.social.facebook.api.FacebookProfile;
@@ -92,5 +93,18 @@ class UserTemplate extends AbstractFacebookOperations implements UserOperations 
 			}
 		}			
 		return permissions;
+	}
+	
+	@SuppressWarnings("unchecked")
+	public boolean postNotifcation(String userId, String href, String template) {
+		requireAuthorization();
+		
+		MultiValueMap<String, Object> map = new LinkedMultiValueMap<String, Object>();
+		map.set("href", href);
+		map.set("template", template);
+		
+		String uri = GraphApi.GRAPH_API_URL + userId + "/notifications";
+		Map<String, Object> response = restTemplate.postForObject(uri, map, Map.class);
+		return (Boolean)response.get("success");
 	}
 }

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/testdata/error-invalid-access-token.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/testdata/error-invalid-access-token.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "message": "Invalid OAuth access token.", 
+    "type": "OAuthException", 
+    "code": 190
+  }
+}

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/testdata/notifications.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/testdata/notifications.json
@@ -1,0 +1,3 @@
+{
+	"success" : true
+}


### PR DESCRIPTION
Hi,

The Facebook API now supports sending notifications from your app to a user.  This commit adds a postNotifcation method to userOperations to allow this from within Spring Social.  It includes the new interface method, the implementation and some tests.

You can find details from Facebook here: https://developers.facebook.com/docs/app_notifications/

Thanks!
Doug
