### PR TITLE
SOCIALFB-110: Added signin controller to support Facebook Canvas applications.

### DIFF
--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.facebook.web;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.social.connect.Connection;
+import org.springframework.social.connect.ConnectionFactoryLocator;
+import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.social.connect.support.OAuth2ConnectionFactory;
+import org.springframework.social.connect.web.SignInAdapter;
+import org.springframework.social.facebook.api.Facebook;
+import org.springframework.social.oauth2.AccessGrant;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.view.RedirectView;
+
+/**
+ * Sign in controller that uses the signed_request parameter that Facebook gives to Canvas applications to obtain an access token.
+ * If no access token exists in signed_request, this controller will redirect the top-level browser window to Facebook's authorization dialog.
+ * When Facebook redirects back from the authorization dialog, the signed_request parameter should contain an access token.
+ * @author Craig Walls
+ */
+@Controller
+@RequestMapping(value="/canvas")
+public class CanvasSignInController {
+	
+	private final static Log logger = LogFactory.getLog(CanvasSignInController.class);
+
+	private final String clientId;
+	
+	private final String canvasPage;
+
+	private final ConnectionFactoryLocator connectionFactoryLocator;
+
+	private final UsersConnectionRepository usersConnectionRepository;
+
+	private final SignInAdapter signInAdapter;
+	
+	private final SignedRequestDecoder signedRequestDecoder;
+	
+	private String postSignInUrl = "/";
+
+	@Inject
+	public CanvasSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter, String clientId, String clientSecret, String canvasPage) {
+		this.usersConnectionRepository = usersConnectionRepository;
+		this.signInAdapter = signInAdapter;
+		this.clientId = clientId;
+		this.canvasPage = canvasPage;
+		this.connectionFactoryLocator = connectionFactoryLocator;
+		this.signedRequestDecoder = new SignedRequestDecoder(clientSecret);
+	}
+	
+	public void setPostSignInUrl(String postSignInUrl) {
+		this.postSignInUrl = postSignInUrl;
+	}
+
+	@RequestMapping(method=RequestMethod.POST)
+	public View signin(Model model, NativeWebRequest request) throws SignedRequestException {
+		String signedRequest = request.getParameter("signed_request");
+		if (signedRequest == null) {
+			logger.info("Expected a signed_request parameter, but none given. Redirecting to the application's Canvas Page: " + canvasPage);
+			return new RedirectView(canvasPage, false);
+		}
+		
+		Map<String, ?> decodedSignedRequest = signedRequestDecoder.decodeSignedRequest(signedRequest);
+		String accessToken = (String) decodedSignedRequest.get("oauth_token");
+		if (accessToken == null) {
+			logger.info("No access token in the signed_request parameter. Redirecting to the authorization dialog.");
+			model.addAttribute("clientId", clientId);
+			model.addAttribute("canvasPage", canvasPage);
+			return new AuthorizationDialogRedirectView();
+		}
+
+		logger.info("Access token available in signed_request parameter. Creating connection and signing in.");
+		OAuth2ConnectionFactory<Facebook> connectionFactory = (OAuth2ConnectionFactory<Facebook>) connectionFactoryLocator.getConnectionFactory(Facebook.class);
+		AccessGrant accessGrant = new AccessGrant(accessToken);
+		Connection<Facebook> connection = connectionFactory.createConnection(accessGrant);
+		handleSignIn(connection, request);
+		logger.info("Signed in. Redirecting to post-signin page.");
+		return new RedirectView(postSignInUrl, true); 
+	}
+
+	
+	private void handleSignIn(Connection<Facebook> connection, NativeWebRequest request) {
+		List<String> userIds = usersConnectionRepository.findUserIdsWithConnection(connection);
+		if (userIds.size() == 1) {
+			usersConnectionRepository.createConnectionRepository(userIds.get(0)).updateConnection(connection);
+			signInAdapter.signIn(userIds.get(0), connection, request);
+		} else {
+			// TODO: This should never happen, but need to figure out what to do if it does happen. 
+			logger.error("Expected exactly 1 matching user. Got " + userIds.size() + " metching users.");
+		}
+	}
+	
+	private static final class AuthorizationDialogRedirectView implements View {
+		public String getContentType() {
+			return "text/html";
+		}
+
+		public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+			String clientId = (String) model.get("clientId");
+			String canvasPage = (String) model.get("canvasPage");
+			response.getWriter().write("<script>");
+			response.getWriter().write("top.location.href='https://www.facebook.com/dialog/oauth?client_id=" + clientId + "&redirect_uri=" + canvasPage + "';");
+			response.getWriter().write("</script>");
+			response.flushBuffer();
+		}
+	}
+
+}


### PR DESCRIPTION
Facebook Canvas applications do not follow a pure OAuth2 flow*. Therefore, although it is possible to make Spring Social's ProviderSignInController work with canvas apps, it is not optimal. This change introduces a CanvasSignInController that handles signin by accepting an access token from the signed_request parameter given to the application by Facebook.
- Actually, they do follow the OAuth2 Authorization Code Grant flow, but the flow is handled at the top-level...within Facebook itself. The actual canvas application, which is contained within an iframe at Facebook, is given the access token from Facebook via a POST to its canvas page URL and within a signed_request parameter.
