### PR TITLE
Allow passing of additional parameters to OpenGraphOperations publishAct...

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.social.facebook.api;
 
+import org.springframework.util.MultiValueMap;
+
 /**
  * Defines operations for working with Facebook OpenGraph actions.
  * @author habuma
@@ -29,5 +31,15 @@ public interface OpenGraphOperations {
 	 * @return the ID of the posted action.
 	 */
 	String publishAction(String action, String objectType, String objectUrl);
+
+    /**
+     * Posts an action for an object specified by the given object URL.
+     * @param action The application specific action to post, without the application's namespace. (eg, "drink")
+     * @param objectType The application specific object type, without the application's namespace. (eg, "beverage")
+     * @param objectUrl The URL of the object that is the target of the action.
+     * @param parameters Optional parameters - see https://developers.facebook.com/docs/opengraph/using-actions/#publish
+     * @return the ID of the posted action.
+     */
+    String publishAction(String action, String objectType, String objectUrl, MultiValueMap<String, Object> parameters);
 	
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
@@ -31,12 +31,15 @@ class OpenGraphTemplate extends AbstractFacebookOperations implements OpenGraphO
 	}
 
 	public String publishAction(String action, String objectType, String objectUrl) {
+		return publishAction(action, objectType, objectUrl, new LinkedMultiValueMap<String, Object>());
+	}
+	
+	public String publishAction(String action, String objectType, String objectUrl, MultiValueMap<String, Object> parameters) {
 		requireAuthorization();
 		requireApplicationNamespace();
-		MultiValueMap<String, Object> parameters = new LinkedMultiValueMap<String, Object>();
 		parameters.set(objectType, objectUrl);
 		return graphApi.publish("me", graphApi.getApplicationNamespace() + ":" + action, parameters);
-	}
+	}	
 
 	private void requireApplicationNamespace() {
 		String applicationNamespace = graphApi.getApplicationNamespace();


### PR DESCRIPTION
...ion

Currently, there is no way to take advantage of explicit sharing.  The publishAction of OpenGraphOperations needs to support passing additional parameters such that fb:explicitly_shared can be passed.
