### PR TITLE
adding the app notification send of the graph api

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
@@ -67,4 +67,19 @@ public interface OpenGraphOperations {
 	String publishAction(String action, String objectType, String objectUrl);
 	
 	String publishAction(String action, MultiValueMap<String, Object> parameters, boolean builtInAction);
+	
+	/**
+	 * The way a application sends notification to users
+	 * 
+	 * @param userId the facebook user id
+	 * @param href The relative path/GET params of the  canvas APP
+	 * @param template The customized text of the notification. See 
+	 * https://developers.facebook.com/docs/games/notifications/#templating for
+	 * customized messages
+	 * 
+	 * @return true if the user received the notification false otherwise
+	 * 
+	 * @see https://developers.facebook.com/docs/games/notifications/
+	 */
+	void sendAppNotification(String userId, String href, String template);
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
@@ -34,6 +34,7 @@ import org.springframework.social.facebook.api.Facebook;
 import org.springframework.social.facebook.api.FeedOperations;
 import org.springframework.social.facebook.api.FqlOperations;
 import org.springframework.social.facebook.api.FriendOperations;
+import org.springframework.social.facebook.api.GraphApi;
 import org.springframework.social.facebook.api.GroupOperations;
 import org.springframework.social.facebook.api.ImageType;
 import org.springframework.social.facebook.api.LikeOperations;
@@ -103,6 +104,10 @@ public class FacebookTemplate extends AbstractOAuth2ApiBinding implements Facebo
 
 	private String applicationNamespace;
 
+	private String appId;
+
+	private String appSecret;
+
 	/**
 	 * Create a new instance of FacebookTemplate.
 	 * This constructor creates a new FacebookTemplate able to perform unauthenticated operations against Facebook's Graph API.
@@ -121,12 +126,14 @@ public class FacebookTemplate extends AbstractOAuth2ApiBinding implements Facebo
 	 * @param accessToken An access token given by Facebook after a successful OAuth 2 authentication (or through Facebook's JS library).
 	 */
 	public FacebookTemplate(String accessToken) {
-		this(accessToken, null);
+		this(accessToken, null, null, null);
 	}
 	
-	public FacebookTemplate(String accessToken, String applicationNamespace) {
+	public FacebookTemplate(String accessToken, String appId, String appSecret, String appNamespace) {
 		super(accessToken);
-		this.applicationNamespace = applicationNamespace;
+		this.appId = appId;
+		this.appSecret = appSecret;
+		this.applicationNamespace = appNamespace;
 		initialize();
 	}
 
@@ -314,7 +321,7 @@ public class FacebookTemplate extends AbstractOAuth2ApiBinding implements Facebo
 	}
 		
 	private void initSubApis() {
-		openGraphOperations = new OpenGraphTemplate(this, isAuthorized());
+		openGraphOperations = new OpenGraphTemplate(this, appId, appSecret, isAuthorized());
 		userOperations = new UserTemplate(this, getRestTemplate(), isAuthorized());
 		placesOperations = new PlacesTemplate(this, isAuthorized());
 		friendOperations = new FriendTemplate(this, getRestTemplate(), isAuthorized());

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
@@ -43,6 +43,10 @@ class OpenGraphTemplate extends AbstractFacebookOperations implements OpenGraphO
 	
 	private FitnessActions fitnessActions;
 
+	private String appId;
+
+	private String appSecret;
+
 	public OpenGraphTemplate(GraphApi graphApi, boolean isAuthorizedForUser) {
 		super(isAuthorizedForUser);
 		this.graphApi = graphApi;
@@ -53,6 +57,13 @@ class OpenGraphTemplate extends AbstractFacebookOperations implements OpenGraphO
 		this.fitnessActions = new FitnessActionsTemplate(this);
 	} 
 	
+	public OpenGraphTemplate(FacebookTemplate facebookTemplate, String appId,
+			String appSecret, boolean authorized) {
+		this(facebookTemplate, authorized);
+		this.appId = appId;
+		this.appSecret = appSecret;
+	}
+
 	public GeneralActions generalActions() {
 		return generalActions;
 	}
@@ -89,6 +100,17 @@ class OpenGraphTemplate extends AbstractFacebookOperations implements OpenGraphO
 			requireApplicationNamespace();
 		}
 		return graphApi.publish("me", action, parameters);
+	}
+	
+	public void sendAppNotification(String userId, String href, String template) {
+		requireAuthorization();
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<String, String>();
+
+		map.set("access_token", appId + "|" + appSecret);
+		map.set("href", href);
+		map.set("template", template);
+		
+		graphApi.post(userId, "notifications", map);
 	}
 
 	private void requireApplicationNamespace() {

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
@@ -27,6 +27,8 @@ import org.springframework.social.oauth2.AbstractOAuth2ServiceProvider;
 public class FacebookServiceProvider extends AbstractOAuth2ServiceProvider<Facebook> {
 
 	private String appNamespace;
+	private String appId;
+	private String appSecret;
 
 	/**
 	 * Creates a FacebookServiceProvider for the given application ID, secret, and namespace.
@@ -36,11 +38,13 @@ public class FacebookServiceProvider extends AbstractOAuth2ServiceProvider<Faceb
 	 */
 	public FacebookServiceProvider(String appId, String appSecret, String appNamespace) {
 		super(new FacebookOAuth2Template(appId, appSecret));
+		this.appId = appId;
+		this.appSecret = appSecret;
 		this.appNamespace = appNamespace;
 	}
 
 	public Facebook getApi(String accessToken) {
-		return new FacebookTemplate(accessToken, appNamespace);
+		return new FacebookTemplate(accessToken, appId, appSecret, appNamespace);
 	}
 	
 }


### PR DESCRIPTION
I needed this operation graph api and how not yet see it in the master I decided to share. I did not test cases, because I did not think necessary. In the case of incorrect access token (appId | appSecret) the template throws exceptions friendly.

For more information see https://developers.facebook.com/docs/games/notifications/
