### PR TITLE
Add the Spring IO plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath 'me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1'
         classpath('org.asciidoctor:asciidoctor-gradle-plugin:0.7.0')
         classpath('org.asciidoctor:asciidoctor-java-integration:0.1.4.preview.1')
+        classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
     }
 }
 
@@ -30,7 +31,9 @@ configure(allprojects - docProjects) {
 
     sourceSets.test.resources.srcDirs = ['src/test/resources', 'src/test/java']
 
-    test.systemProperty("java.awt.headless", "true")
+    tasks.withType(Test).all {
+        systemProperty("java.awt.headless", "true")
+    }
 
     repositories {
         maven { url "http://repo.spring.io/libs-snapshot" }
@@ -68,6 +71,18 @@ ext.javadocLinks = [
 
 configure(subprojects - docProjects) { subproject ->
     apply from: "${rootProject.projectDir}/publish-maven.gradle"
+
+    if (project.hasProperty('platformVersion')) {
+        apply plugin: 'spring-io'
+
+        repositories {
+            maven { url "https://repo.spring.io/libs-snapshot" }
+        }
+
+        dependencies {
+            springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+        }
+    }
 
     jar {
         manifest.attributes['Implementation-Title'] = subproject.name


### PR DESCRIPTION
Configure the Spring IO plugin such that it's only applied when the build is run with `-PplatformVersion=<version>`. This `platformVersion` property is used to determine the version of the Platform that will
be used when running the `springIoCheck` task. The plugin can be used by running a build as follows:

```
./gradlew clean springIoCheck -PplatformVersion=1.0.0.BUILD-SNAPSHOT -PJDK7_HOME=… -PJDK8_HOME=…
```

This will test the project on JDK 7 and JDK 8 using the dependencies defined in the latest snapshot of Spring IO Platform 1.0.0.
