### PR TITLE
Facebook graph version flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ spring-social-core/src/test/java/exploration
 **/.project
 **/.settings
 **/bin
+*.iml
+*.ipr
+*.iws

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
@@ -72,16 +72,23 @@ public class CanvasSignInController {
 
 	private String scope;
 
+    private String graphVersion;
+
 	@Inject
 	public CanvasSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter, String clientId, String clientSecret, String canvasPage) {
+		this(connectionFactoryLocator, usersConnectionRepository, signInAdapter, clientId, clientSecret, canvasPage, "v2.2");
+	}
+
+	public CanvasSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter, String clientId, String clientSecret, String canvasPage, String graphVersion) {
 		this.usersConnectionRepository = usersConnectionRepository;
 		this.signInAdapter = signInAdapter;
 		this.clientId = clientId;
 		this.canvasPage = canvasPage;
 		this.connectionFactoryLocator = connectionFactoryLocator;
 		this.signedRequestDecoder = new SignedRequestDecoder(clientSecret);
+        this.graphVersion = graphVersion;
 	}
-	
+
 	/**
 	 * The URL or path to redirect to after successful canvas authorization.
 	 * @param postSignInUrl the url to redirect to after successful canvas authorization. Defaults to "/".
@@ -131,7 +138,7 @@ public class CanvasSignInController {
 					String clientId = (String) model.get("clientId");
 					String canvasPage = (String) model.get("canvasPage");
 					String scope = (String) model.get("scope");
-					String redirectUrl = "https://www.facebook.com/v1.0/dialog/oauth?client_id=" + clientId + "&redirect_uri=" + canvasPage;
+					String redirectUrl = "https://www.facebook.com/" + graphVersion + "/dialog/oauth?client_id=" + clientId + "&redirect_uri=" + canvasPage;
 					if (scope != null) {
 						redirectUrl += "&scope=" + formEncode(scope);
 					}

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
@@ -32,6 +32,7 @@ import org.springframework.social.connect.UsersConnectionRepository;
 import org.springframework.social.connect.support.OAuth2ConnectionFactory;
 import org.springframework.social.connect.web.SignInAdapter;
 import org.springframework.social.facebook.api.Facebook;
+import org.springframework.social.facebook.api.GraphApi;
 import org.springframework.social.oauth2.AccessGrant;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -76,7 +77,7 @@ public class CanvasSignInController {
 
 	@Inject
 	public CanvasSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter, String clientId, String clientSecret, String canvasPage) {
-		this(connectionFactoryLocator, usersConnectionRepository, signInAdapter, clientId, clientSecret, canvasPage, "v2.2");
+		this(connectionFactoryLocator, usersConnectionRepository, signInAdapter, clientId, clientSecret, canvasPage,  GraphApi.DEFAULT_GRAPH_API_VERSION);
 	}
 
 	public CanvasSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter, String clientId, String clientSecret, String canvasPage, String graphVersion) {

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
@@ -151,7 +151,14 @@ public interface GraphApi {
 	 * 			May be null if no namespace was specified.
 	 */
 	String getApplicationNamespace();
+
+    /**
+     * @return The Graph version associated with this GraphApi instance.
+     */
+    String getGraphApiUrl();
 	
-	static final String GRAPH_API_URL = "https://graph.facebook.com/v2.2/";
+	static final String GRAPH_API_URL_VERSIONLESS = "https://graph.facebook.com/";
+
+    static final String DEFAULT_GRAPH_API_VERSION = "v2.2";
 
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
@@ -74,7 +74,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 		
 	public PagedList<Post> getFeed(String ownerId, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		JsonNode responseNode = fetchConnectionList(GraphApi.GRAPH_API_URL + ownerId + "/feed", pagedListParameters);
+        JsonNode responseNode = fetchConnectionList(graphApi.getGraphApiUrl() + ownerId + "/feed", pagedListParameters);
 		return deserializeList(responseNode, null, Post.class);
 	}
 
@@ -84,7 +84,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> getHomeFeed(PagingParameters pagedListParameters) {
 		requireAuthorization();
-		JsonNode responseNode = fetchConnectionList(GraphApi.GRAPH_API_URL + "me/home", pagedListParameters);
+        JsonNode responseNode = fetchConnectionList(graphApi.getGraphApiUrl() + "me/home", pagedListParameters);
 		return deserializeList(responseNode, null, Post.class);
 	}
 
@@ -102,7 +102,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> getStatuses(String userId, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		JsonNode responseNode = fetchConnectionList(GraphApi.GRAPH_API_URL + userId + "/statuses", pagedListParameters);
+        JsonNode responseNode = fetchConnectionList(graphApi.getGraphApiUrl() + userId + "/statuses", pagedListParameters);
 		return deserializeList(responseNode, "status", Post.class);
 	}
 
@@ -120,7 +120,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> getLinks(String ownerId, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		JsonNode responseNode = fetchConnectionList(GraphApi.GRAPH_API_URL + ownerId + "/links", pagedListParameters);
+        JsonNode responseNode = fetchConnectionList(graphApi.getGraphApiUrl() + ownerId + "/links", pagedListParameters);
 		return deserializeList(responseNode, "link", Post.class);
 	}
 
@@ -138,13 +138,13 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> getPosts(String ownerId, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		JsonNode responseNode = fetchConnectionList(GraphApi.GRAPH_API_URL + ownerId + "/posts", pagedListParameters);
+        JsonNode responseNode = fetchConnectionList(graphApi.getGraphApiUrl() + ownerId + "/posts", pagedListParameters);
 		return deserializeList(responseNode, null, Post.class);
 	}
 	
 	public Post getPost(String entryId) {
 		requireAuthorization();
-		ObjectNode responseNode = (ObjectNode) restTemplate.getForObject(GraphApi.GRAPH_API_URL + entryId, JsonNode.class);
+        ObjectNode responseNode = (ObjectNode) restTemplate.getForObject(graphApi.getGraphApiUrl() + entryId, JsonNode.class);
 		return deserializePost(null, Post.class, responseNode);
 	}
 
@@ -189,7 +189,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	}
 	
 	public PagedList<Post> searchPublicFeed(String query, PagingParameters pagedListParameters) {
-		String url = GraphApi.GRAPH_API_URL + "search?q={query}&type=post";
+        String url = graphApi.getGraphApiUrl() + "search?q={query}&type=post";
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("query", query);
 		if (pagedListParameters.getLimit() != null) {
@@ -214,7 +214,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> searchHomeFeed(String query, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		URIBuilder uriBuilder = URIBuilder.fromUri(GraphApi.GRAPH_API_URL + "me/home").queryParam("q", query);
+        URIBuilder uriBuilder = URIBuilder.fromUri(graphApi.getGraphApiUrl() + "me/home").queryParam("q", query);
 		uriBuilder = appendPagedListParameters(pagedListParameters, uriBuilder);
 		URI uri = uriBuilder.build();
 		JsonNode responseNode = restTemplate.getForObject(uri, JsonNode.class);
@@ -235,7 +235,7 @@ class FeedTemplate extends AbstractFacebookOperations implements FeedOperations 
 	
 	public PagedList<Post> searchUserFeed(String userId, String query, PagingParameters pagedListParameters) {
 		requireAuthorization();
-		URIBuilder uriBuilder = URIBuilder.fromUri(GraphApi.GRAPH_API_URL + userId + "/feed").queryParam("q", query);
+        URIBuilder uriBuilder = URIBuilder.fromUri(graphApi.getGraphApiUrl() + userId + "/feed").queryParam("q", query);
 		uriBuilder = appendPagedListParameters(pagedListParameters, uriBuilder);		
 		URI uri = uriBuilder.build();
 		JsonNode responseNode = restTemplate.getForObject(uri, JsonNode.class);

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
@@ -76,8 +76,8 @@ class FriendTemplate extends AbstractFacebookOperations implements FriendOperati
 	}
 	
 	public PagedList<String> getFriendIds(String userId) {
-		requireAuthorization();		
-		URI uri = URIBuilder.fromUri(GraphApi.GRAPH_API_URL + userId + "/friends").queryParam("fields", "id").build();
+		requireAuthorization();
+        URI uri = URIBuilder.fromUri(graphApi.getGraphApiUrl() + userId + "/friends").queryParam("fields", "id").build();
 		@SuppressWarnings("unchecked")
 		Map<String,PagedList<Map<String, String>>> response = restTemplate.getForObject(uri, Map.class);
 		List<Map<String,String>> entryList = response.get("data");

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
@@ -72,7 +72,7 @@ class UserTemplate extends AbstractFacebookOperations implements UserOperations 
 
 	public List<String> getUserPermissions() {
 		requireAuthorization();
-		JsonNode responseNode = restTemplate.getForObject(GraphApi.GRAPH_API_URL + "me/permissions", JsonNode.class);
+        JsonNode responseNode = restTemplate.getForObject(graphApi.getGraphApiUrl() + "me/permissions", JsonNode.class);
 		return deserializePermissionsNodeToList(responseNode);
 	}
 

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookAdapter.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookAdapter.java
@@ -43,7 +43,7 @@ public class FacebookAdapter implements ApiAdapter<Facebook> {
 		values.setProviderUserId(profile.getId());
 		values.setDisplayName(profile.getName());
 		values.setProfileUrl("https://www.facebook.com/app_scoped_user_id/" + profile.getId() + '/');
-		values.setImageUrl("https://graph.facebook.com/v2.2/" + profile.getId() + "/picture");
+		values.setImageUrl("https://graph.facebook.com/" + profile.getId() + "/picture");
 	}
 
 	public UserProfile fetchUserProfile(Facebook facebook) {

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.social.facebook.api.GraphApi;
 import org.springframework.social.oauth2.AccessGrant;
 import org.springframework.social.oauth2.OAuth2Template;
 import org.springframework.social.support.ClientHttpRequestFactorySelector;
@@ -40,7 +41,7 @@ public class FacebookOAuth2Template extends OAuth2Template {
 	}
 
 	public FacebookOAuth2Template(String clientId, String clientSecret) {
-		this(clientId, clientSecret, "v2.2");
+		this(clientId, clientSecret, GraphApi.DEFAULT_GRAPH_API_VERSION);
 		setUseParametersForClientAuthentication(true);
 	}
 

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookOAuth2Template.java
@@ -34,8 +34,13 @@ import org.springframework.web.client.RestTemplate;
  */
 public class FacebookOAuth2Template extends OAuth2Template {
 
+	public FacebookOAuth2Template(String clientId, String clientSecret, String graphVersion) {
+		super(clientId, clientSecret, "https://www.facebook.com/" + graphVersion + "/dialog/oauth", "https://graph.facebook.com/" + graphVersion +"/oauth/access_token");
+		setUseParametersForClientAuthentication(true);
+	}
+
 	public FacebookOAuth2Template(String clientId, String clientSecret) {
-		super(clientId, clientSecret, "https://www.facebook.com/v2.2/dialog/oauth", "https://graph.facebook.com/v2.2/oauth/access_token");
+		this(clientId, clientSecret, "v2.2");
 		setUseParametersForClientAuthentication(true);
 	}
 

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AbstractFacebookApiTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AbstractFacebookApiTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 public class AbstractFacebookApiTest {
 	protected static final String ACCESS_TOKEN = "someAccessToken";
 	protected static final String APP_ACCESS_TOKEN = "123456|abcdefg987654321";
+    protected static final String GRAPH_API_VERSION = "v2.2";
 
 	protected FacebookTemplate facebook;
 	protected FacebookTemplate unauthorizedFacebook;
@@ -46,12 +47,12 @@ public class AbstractFacebookApiTest {
 		unauthorizedFacebook = new FacebookTemplate();
 		unauthorizedMockServer = MockRestServiceServer.createServer(unauthorizedFacebook.getRestTemplate());
 		
-		appFacebook = new FacebookTemplate(APP_ACCESS_TOKEN);
+		appFacebook = new FacebookTemplate(APP_ACCESS_TOKEN, null, GRAPH_API_VERSION);
 		appFacebookMockServer = MockRestServiceServer.createServer(appFacebook.getRestTemplate());
 	}
 
 	protected FacebookTemplate createFacebookTemplate() {
-		return new FacebookTemplate(ACCESS_TOKEN);
+		return new FacebookTemplate(ACCESS_TOKEN, null, GRAPH_API_VERSION);
 	}
 
 	protected Resource jsonResource(String filename) {
@@ -65,6 +66,10 @@ public class AbstractFacebookApiTest {
 			return null;
 		}
 	}
+
+    protected String getGraphApiUrl() {
+        return GraphApi.GRAPH_API_URL_VERSIONLESS + GRAPH_API_VERSION + "/";
+    }
 
 	private static final DateFormat FB_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH);
 

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AchievementTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AchievementTemplateTest.java
@@ -36,7 +36,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAchievement() throws Exception {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "1403783649909361"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1403783649909361"))
 			.andExpect(method(GET))
 			.andRespond(withSuccess(jsonResource("achievement"), MediaType.APPLICATION_JSON));
 		
@@ -46,7 +46,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getAchievements() throws Exception {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/achievements"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/achievements"))
 			.andExpect(method(GET))
 			.andRespond(withSuccess(jsonResource("achievements"), MediaType.APPLICATION_JSON));
 		
@@ -58,7 +58,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void postAchievement() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/achievements"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/achievements"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth " + ACCESS_TOKEN))
 			.andExpect(content().string("achievement=http%3A%2F%2Fexample.com%2Fachievement"))
@@ -71,7 +71,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void deleteAchievement() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/achievements"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/achievements"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth " + ACCESS_TOKEN))
 			.andExpect(content().string("achievement=http%3A%2F%2Fexample.com%2Fachievement&method=delete"))
@@ -87,7 +87,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getAchievementTypes() throws Exception {
-		appFacebookMockServer.expect(requestTo("https://graph.facebook.com/v2.2/app/achievements"))
+		appFacebookMockServer.expect(requestTo(getGraphApiUrl() + "app/achievements"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth " + APP_ACCESS_TOKEN))
 			.andRespond(withSuccess(jsonResource("achievement-types"), MediaType.APPLICATION_JSON));
@@ -100,7 +100,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAchievementType() throws Exception {
-		appFacebookMockServer.expect(requestTo("https://graph.facebook.com/v2.2/651053301631017"))
+		appFacebookMockServer.expect(requestTo(getGraphApiUrl() + "651053301631017"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth " + APP_ACCESS_TOKEN))
 			.andRespond(withSuccess(jsonResource("achievement-type"), MediaType.APPLICATION_JSON));
@@ -111,7 +111,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void createAchievementType() throws Exception {
-		appFacebookMockServer.expect(requestTo("https://graph.facebook.com/v2.2/app/achievements"))
+		appFacebookMockServer.expect(requestTo(getGraphApiUrl() + "app/achievements"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth " + APP_ACCESS_TOKEN))
 			.andExpect(content().string("achievement=http%3A%2F%2Fexample.com%2Fachievement&display_order=2"))
@@ -123,7 +123,7 @@ public class AchievementTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void removeAchievementType() throws Exception {
-		appFacebookMockServer.expect(requestTo("https://graph.facebook.com/v2.2/app/achievements"))
+		appFacebookMockServer.expect(requestTo(getGraphApiUrl() + "app/achievements"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth " + APP_ACCESS_TOKEN))
 			.andExpect(content().string("achievement=http%3A%2F%2Fexample.com%2Fachievement&method=delete"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/BookActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/BookActionsTemplateTest.java
@@ -27,7 +27,7 @@ public class BookActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void readBook() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/book.reads"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/book.reads"))
 			.andExpect(method(POST))
 			.andExpect(content().string("book=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&progress%3Atimestamp=1378241299&progress%3Apercent_complete=3.1415927"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -39,7 +39,7 @@ public class BookActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void quoteBook() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/books.quotes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/books.quotes"))
 			.andExpect(method(POST))
 			.andExpect(content().string("book=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&body=Test+quote"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -51,7 +51,7 @@ public class BookActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void rateBook() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/books.rates"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/books.rates"))
 			.andExpect(method(POST))
 			.andExpect(content().string("book=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&rating%3Avalue=3.5&rating%3Ascale=5"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -63,7 +63,7 @@ public class BookActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void wantsToRead() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/books.wants_to_read"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/books.wants_to_read"))
 			.andExpect(method(POST))
 			.andExpect(content().string("book=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
@@ -33,7 +33,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getComments() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/comments?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/comments?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("comments"), MediaType.APPLICATION_JSON));
@@ -52,7 +52,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getComments_withOffsetAndLimit() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/comments?offset=75&limit=100"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/comments?offset=75&limit=100"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("comments"), MediaType.APPLICATION_JSON));
@@ -83,7 +83,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getComment() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/1533260333_122829644452184_587062?fields=id%2Cattachment%2Ccan_comment%2Ccan_remove%2Ccomment_count%2Ccreated_time%2Cfrom%2Clike_count%2Cmessage%2Cparent%2Cuser_likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1533260333_122829644452184_587062?fields=id%2Cattachment%2Ccan_comment%2Ccan_remove%2Ccomment_count%2Ccreated_time%2Cfrom%2Clike_count%2Cmessage%2Cparent%2Cuser_likes"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("comment"), MediaType.APPLICATION_JSON));
@@ -112,7 +112,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void addComment() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/comments"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/comments"))
 			.andExpect(method(POST))
 			.andExpect(content().string("message=Cool+beans"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -127,7 +127,7 @@ public class CommentTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void deleteComment() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/1533260333_122829644452184_587062"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1533260333_122829644452184_587062"))
 			.andExpect(method(POST))
 			.andExpect(content().string("method=delete"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/ErrorHandlingTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/ErrorHandlingTest.java
@@ -45,7 +45,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	@Test
 	public void unknownAlias() {
 		try {
-			mockServer.expect(requestTo("https://graph.facebook.com/v2.2/dummyalias"))
+			mockServer.expect(requestTo(getGraphApiUrl() + "dummyalias"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withStatus(HttpStatus.NOT_FOUND).body(jsonResource("error-404-unknown-alias")).contentType(MediaType.APPLICATION_JSON));
@@ -59,7 +59,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	@Test
 	public void unknownPath() {
 		try {
-			mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/boguspath"))
+			mockServer.expect(requestTo(getGraphApiUrl() + "me/boguspath"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withBadRequest().body(jsonResource("error-400-unknown-path")).contentType(MediaType.APPLICATION_JSON));
@@ -74,7 +74,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	public void resource_noAccessToken() {
 		FacebookTemplate facebook = new FacebookTemplate(); // use anonymous FacebookTemplate in this test
 		MockRestServiceServer mockServer = MockRestServiceServer.createServer(facebook.getRestTemplate());
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andRespond(withBadRequest().body(jsonResource("error-400-resource-no-access-token")).contentType(MediaType.APPLICATION_JSON));
 		facebook.userOperations().getUserProfile();
@@ -84,7 +84,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	public void currentUser_noAccessToken() {
 		FacebookTemplate facebook = new FacebookTemplate(); // use anonymous FacebookTemplate in this test
 		MockRestServiceServer mockServer = MockRestServiceServer.createServer(facebook.getRestTemplate());
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andRespond(withBadRequest().body(jsonResource("error-400-current-user-no-token")).contentType(MediaType.APPLICATION_JSON));
 		facebook.userOperations().getUserProfile();
@@ -92,7 +92,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = ExpiredAuthorizationException.class)
 	public void currentUser_expiredToken() { // The token has expired
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-token-expired")).contentType(MediaType.APPLICATION_JSON));
@@ -102,7 +102,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = RevokedAuthorizationException.class)
 	public void currentUser_removedApp() { // The user removed the app via Facebook's web application
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-token-removed-app")).contentType(MediaType.APPLICATION_JSON));
@@ -112,7 +112,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = RevokedAuthorizationException.class)
 	public void currentUser_loggedOut() { // The user logged out of Facebook
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-token-logged-out")).contentType(MediaType.APPLICATION_JSON));
@@ -122,7 +122,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = RevokedAuthorizationException.class)
 	public void currentUser_sessionDoesNotMatch() { // The user logged out of Facebook and another user has logged in (?)
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-session-does-not-match")).contentType(MediaType.APPLICATION_JSON));
@@ -132,7 +132,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = RevokedAuthorizationException.class)
 	public void currentUser_changedPassword() { // The user has changed their password
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-token-changed-password")).contentType(MediaType.APPLICATION_JSON));
@@ -142,7 +142,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = InvalidAuthorizationException.class)
 	public void currentUser_unknownInvalidAuthorization() { // The token is invalid, but the reason is not one otherwise expected by this error handler.
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-token-unknown-reason")).contentType(MediaType.APPLICATION_JSON));
@@ -152,7 +152,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = InvalidAuthorizationException.class)
 	public void currentUser_unknownInvalidAppId() { // This shouldn't happen normally, but could if the access token is manually typed and a mistake is made
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-token-invalid-appid")).contentType(MediaType.APPLICATION_JSON));
@@ -162,7 +162,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = InvalidAuthorizationException.class)
 	public void currentUser_unknownInvalidToken() { // This shouldn't happen normally, but could if the access token is manually typed and a mistake is made
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withUnauthorizedRequest().body(jsonResource("error-401-invalid-oauth-access-token")).contentType(MediaType.APPLICATION_JSON));
@@ -173,7 +173,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	@Test
 	public void userHasntAuthorized() {
 		try {
-			mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed"))
+			mockServer.expect(requestTo(getGraphApiUrl() + "me/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withStatus(HttpStatus.FORBIDDEN).body(jsonResource("error-403-not-authorized-for-action")).contentType(MediaType.APPLICATION_JSON));
@@ -187,7 +187,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	@Test
 	public void notAuthorizedForAction() {		
 		try {
-			mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/declined"))
+			mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/declined"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withStatus(HttpStatus.FORBIDDEN).body(jsonResource("error-403-requires-extended-permission")).contentType(MediaType.APPLICATION_JSON));
@@ -202,7 +202,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	@Test(expected = InsufficientPermissionException.class)
 	@Ignore("This doesn't seem to happen anymore...It looks like FB fixed their errors.")
 	public void falseResponse() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/someobject"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "someobject"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("false", MediaType.APPLICATION_JSON));
@@ -211,7 +211,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 
 	@Test(expected = RateLimitExceededException.class)
 	public void rateLimit() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed"))
 			.andExpect(method(POST))
 			.andExpect(content().string("message=Test+Message"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -224,7 +224,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 		
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.setContentType(MediaType.APPLICATION_JSON);
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed"))
 			.andExpect(method(POST))
 			.andExpect(content().string("message=Test+Message"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -234,7 +234,7 @@ public class ErrorHandlingTest extends AbstractFacebookApiTest {
 	
 	@Test(expected = ResourceNotFoundException.class)
 	public void notFound() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/nobody/feed?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "nobody/feed?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withStatus(HttpStatus.NOT_FOUND).body(jsonResource("error-404-unknown-alias")).contentType(MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
@@ -30,7 +30,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getCreated_user() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/events/created?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/events/created?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -40,7 +40,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getCreated_friend() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/events/created?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/events/created?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -50,7 +50,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAttending_user() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/events/attending?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/events/attending?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -60,7 +60,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAttending_friend() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/events/attending?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/events/attending?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -70,7 +70,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMaybe_user() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/events/maybe?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/events/maybe?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -80,7 +80,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMaybe_friend() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/events/maybe?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/events/maybe?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -90,7 +90,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getNoReplies_user() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/events/not_replied?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/events/not_replied?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -100,7 +100,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getNoReplies_friend() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/events/not_replied?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/events/not_replied?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -110,7 +110,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getDeclined_user() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/events/declined?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/events/declined?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -120,7 +120,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getDeclined_friend() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/events/declined?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/events/declined?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-events"), MediaType.APPLICATION_JSON));
@@ -130,7 +130,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getEvent() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
 				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -141,7 +141,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getEvent_withFriendPrivacyLevel() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
 				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -152,7 +152,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getEvent_withLocationAndDescription() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
 				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -172,7 +172,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getInvited() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/invited"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/invited"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("invited"), MediaType.APPLICATION_JSON));
@@ -185,7 +185,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getAttending() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/attending"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/attending"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("attending"), MediaType.APPLICATION_JSON));
@@ -198,7 +198,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMaybeAttending() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/maybe"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/maybe"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("maybe-attending"), MediaType.APPLICATION_JSON));
@@ -211,7 +211,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getNoReplies() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/noreply"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/noreply"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("no-replies"), MediaType.APPLICATION_JSON));
@@ -224,7 +224,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getDeclined() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/declined"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/declined"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("declined"), MediaType.APPLICATION_JSON));
@@ -237,7 +237,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void acceptInvitation() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/attending"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/attending"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("true", MediaType.APPLICATION_JSON));
@@ -252,7 +252,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void maybeInvitation() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/maybe"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/maybe"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("true", MediaType.APPLICATION_JSON));
@@ -267,7 +267,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void declineInvitation() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/193482154020832/declined"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "193482154020832/declined"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("true", MediaType.APPLICATION_JSON));
@@ -282,7 +282,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void search() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/search?offset=0&limit=25&q=Spring+User+Group&type=event"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "search?offset=0&limit=25&q=Spring+User+Group&type=event"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("event-list"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
@@ -35,7 +35,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFeed() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed?limit=25"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -46,7 +46,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFeed_withPagedListParameters_since() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed?limit=25&since=1360384019"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed?limit=25&since=1360384019"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -57,7 +57,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFeed_withPagedListParameters_until() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed?limit=25&until=1360384019"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed?limit=25&until=1360384019"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -68,7 +68,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFeed_withUnknownType() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed?limit=25"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed-with-unknown-type"), MediaType.APPLICATION_JSON));
@@ -90,7 +90,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFeed_forOwnerId() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/12345678/feed?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "12345678/feed?limit=25"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -106,7 +106,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getHomeFeed() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/home?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/home?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -122,7 +122,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getStatuses() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/statuses?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/statuses?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-statuses"), MediaType.APPLICATION_JSON));
@@ -136,7 +136,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getStatuses_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/24680/statuses?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "24680/statuses?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-statuses"), MediaType.APPLICATION_JSON));
@@ -150,7 +150,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getLinks_preOctober2012() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/links?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/links?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("links_preOct2012"), MediaType.APPLICATION_JSON));
@@ -159,7 +159,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getLinks() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/links?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/links?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("links"), MediaType.APPLICATION_JSON));
@@ -173,7 +173,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getLinks_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/13579/links?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "13579/links?limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("links"), MediaType.APPLICATION_JSON));
@@ -187,7 +187,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getPosts() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/posts?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/posts?limit=25"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -203,7 +203,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPosts_forOwnerId() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/12345678/posts?limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "12345678/posts?limit=25"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -219,7 +219,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test 
 	public void getFeedEntry() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/100001387295207_123939024341978"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "100001387295207_123939024341978"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("post"), MediaType.APPLICATION_JSON));
@@ -233,7 +233,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test 
 	public void getFeedEntry_noLikes() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/100001387295207_123939024341978"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "100001387295207_123939024341978"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("post_nolikes"), MediaType.APPLICATION_JSON));
@@ -253,7 +253,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void updateStatus() throws Exception {
 		String requestBody = "message=Hello+Facebook+World";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
@@ -269,7 +269,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test(expected = DuplicateStatusException.class)
 	public void updateStatus_duplicate() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string("message=Duplicate"))
@@ -280,7 +280,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void post_message() throws Exception {
 		String requestBody = "message=Hello+Facebook+World";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
@@ -297,7 +297,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void post_link() throws Exception {
 		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed")).andExpect(method(POST))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed")).andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
@@ -315,7 +315,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void post_NewPost_messageOnly() throws Exception {
 		String requestBody = "message=Hello+Facebook+World";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
@@ -329,7 +329,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 //	@Test
 //	public void post_NewPost_withPrivacy() throws Exception {
 //		String requestBody = "message=Hello+Facebook+World&privacy=%7B%27value%27%3A+%27ALL_FRIENDS%27%7D";
-//		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+//		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 //				.andExpect(method(POST))
 //				.andExpect(header("Authorization", "OAuth someAccessToken"))
 //				.andExpect(content().string(requestBody))
@@ -346,7 +346,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 //	@Test
 //	public void post_NewPost_withCustomPrivacy_allow() throws Exception {
 //		String requestBody = "message=Hello+Facebook+World&privacy=%7B%27value%27%3A+%27CUSTOM%27%2C%27allow%27%3A+%2712345%2C54321%27%7D";
-//		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+//		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 //				.andExpect(method(POST))
 //				.andExpect(header("Authorization", "OAuth someAccessToken"))
 //				.andExpect(content().string(requestBody))
@@ -358,7 +358,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 //	@Test
 //	public void post_NewPost_withCustomPrivacy_deny() throws Exception {
 //		String requestBody = "message=Hello+Facebook+World&privacy=%7B%27value%27%3A+%27CUSTOM%27%2C%27deny%27%3A+%2712345%2C54321%27%7D";
-//		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+//		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 //				.andExpect(method(POST))
 //				.andExpect(header("Authorization", "OAuth someAccessToken"))
 //				.andExpect(content().string(requestBody))
@@ -370,7 +370,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 //	@Test
 //	public void post_NewPost_withCustomPrivacy_allowAndDeny() throws Exception {
 //		String requestBody = "message=Hello+Facebook+World&privacy=%7B%27value%27%3A+%27CUSTOM%27%2C%27allow%27%3A+%2712345%2C54321%27%2C%27deny%27%3A+%2767890%2C98765%27%7D";
-//		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+//		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 //				.andExpect(method(POST))
 //				.andExpect(header("Authorization", "OAuth someAccessToken"))
 //				.andExpect(content().string(requestBody))
@@ -382,7 +382,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void post_NewPost_link() throws Exception {
 		String requestBody = "message=Hello+Facebook+World&link=someLink&name=some+name&caption=some+caption&description=some+description";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
@@ -400,7 +400,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void post_link_toAnotherFeed() throws Exception {
 		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed")).andExpect(method(POST))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed")).andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
@@ -418,7 +418,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void deleteFeedEntry() {
 		String requestBody = "method=delete";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456_78901234"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456_78901234"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken")).andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));
@@ -433,7 +433,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void searchPublicFeed() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/search?q=Dr%20Seuss&type=post&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "search?q=Dr%20Seuss&type=post&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("post-list"), MediaType.APPLICATION_JSON));
@@ -443,7 +443,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void searchHomeFeed() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/home?q=Dr+Seuss&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/home?q=Dr+Seuss&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("post-list"), MediaType.APPLICATION_JSON));
@@ -458,7 +458,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test 
 	public void searchUserFeed_currentUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/feed?q=Football&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/feed?q=Football&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -474,7 +474,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test 
 	public void searchUserFeed_specificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/feed?q=Football&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/feed?q=Football&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
@@ -490,7 +490,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getCheckins() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/posts?offset=0&limit=25&with=location"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/posts?offset=0&limit=25&with=location"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("checkins"), MediaType.APPLICATION_JSON));
@@ -505,7 +505,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getCheckin() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10150431253050580"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10150431253050580"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("checkin"), MediaType.APPLICATION_JSON));
@@ -515,7 +515,7 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getCheckin_withStringLocation() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10150431253050580"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10150431253050580"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("checkin-with-string-location"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FitnessActionTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FitnessActionTemplateTest.java
@@ -27,7 +27,7 @@ public class FitnessActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void runs() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/fitness.runs"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/fitness.runs"))
 			.andExpect(method(POST))
 			.andExpect(content().string("course=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -39,7 +39,7 @@ public class FitnessActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void walks() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/fitness.walks"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/fitness.walks"))
 			.andExpect(method(POST))
 			.andExpect(content().string("course=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -51,7 +51,7 @@ public class FitnessActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void bikes() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/fitness.bikes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/fitness.bikes"))
 			.andExpect(method(POST))
 			.andExpect(content().string("course=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FqlTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FqlTemplateTest.java
@@ -31,7 +31,7 @@ public class FqlTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void query_basic() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/fql?q=SELECT+uid%2C+status_id%2C+message%2C+time%2C+source+FROM+status+WHERE+uid%3Dme%28%29"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "fql?q=SELECT+uid%2C+status_id%2C+message%2C+time%2C+source+FROM+status+WHERE+uid%3Dme%28%29"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("fql-result-basic"), MediaType.APPLICATION_JSON));
@@ -74,7 +74,7 @@ public class FqlTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void query_basicWithFloat() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/fql?q=SELECT+vid%2C+title%2C+length+FROM+video+WHERE+owner%3Dme%28%29"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "fql?q=SELECT+vid%2C+title%2C+length+FROM+video+WHERE+owner%3Dme%28%29"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("fql-result-basic-with-float"), MediaType.APPLICATION_JSON));
@@ -105,7 +105,7 @@ public class FqlTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void query_resultsWithAnObjectField() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/fql?q=select+app_id%2C+display_name%2C+restriction_info+from+application+where+app_id%3D162886103757745"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "fql?q=select+app_id%2C+display_name%2C+restriction_info+from+application+where+app_id%3D162886103757745"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("fql-result-with-object-field"), MediaType.APPLICATION_JSON));
@@ -135,7 +135,7 @@ public class FqlTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void query_resultsWithAnObjectArrayField() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/fql?q=select+uid%2C+name%2C+family+from+user+where+uid%3Dme%28%29"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "fql?q=select+uid%2C+name%2C+family+from+user+where+uid%3Dme%28%29"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("fql-result-list-of-objects"), MediaType.APPLICATION_JSON));
@@ -172,7 +172,7 @@ public class FqlTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void nullChecks() {		
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/fql?q=select+stuff+from+somewhere+where+uid%3Dme%28%29"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "fql?q=select+stuff+from+somewhere+where+uid%3Dme%28%29"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("fql-with-nulls"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
@@ -31,7 +31,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendLists() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/friendlists"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/friendlists"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friend-lists"), MediaType.APPLICATION_JSON));
@@ -46,7 +46,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendList() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "11929590579"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "11929590579"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friend-list"), MediaType.APPLICATION_JSON));
@@ -62,7 +62,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriends() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/friends"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/friends"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friends"), MediaType.APPLICATION_JSON));
@@ -77,7 +77,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriends_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "912873465/friends"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "912873465/friends"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friends"), MediaType.APPLICATION_JSON));
@@ -92,7 +92,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendIds() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/friends?fields=id"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/friends?fields=id"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friend-ids"), MediaType.APPLICATION_JSON));
@@ -107,7 +107,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendIds_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "912873465/friends?fields=id"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "912873465/friends?fields=id"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("friend-ids"), MediaType.APPLICATION_JSON));
@@ -123,7 +123,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendProfiles() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/friends?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/friends?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-profiles"), MediaType.APPLICATION_JSON));
@@ -138,7 +138,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFriendProfiles_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "1234567/friends?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1234567/friends?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-profiles"), MediaType.APPLICATION_JSON));
@@ -153,7 +153,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getFamily() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/family"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/family"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("family"), MediaType.APPLICATION_JSON));
@@ -168,7 +168,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getFamily_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "12345678900/family"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "12345678900/family"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("family"), MediaType.APPLICATION_JSON));
@@ -184,7 +184,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	@Ignore("Graph API doesn't seem to support this for any user other than /me.")
 	public void getMutualFriends_forSpecificUser() {
-//		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "9876543210/mutualfriends?user=12345678900"))
+//		mockServer.expect(requestTo(getGraphUrl() + "9876543210/mutualfriends?user=12345678900"))
 //			.andExpect(method(GET))
 //			.andExpect(header("Authorization", "OAuth someAccessToken"))
 //			.andRespond(withResponse(jsonResource("friends"), responseHeaders));
@@ -194,7 +194,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getSubscribedTo() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/subscribedTo"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/subscribedTo"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("subscribe-list"), MediaType.APPLICATION_JSON));
@@ -208,7 +208,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getSubscribedTo_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "9876543210/subscribedTo"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "9876543210/subscribedTo"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("subscribe-list"), MediaType.APPLICATION_JSON));
@@ -222,7 +222,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getSubscribers() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/subscribers"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/subscribers"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("subscribe-list"), MediaType.APPLICATION_JSON));
@@ -236,7 +236,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getSubscribers_forSpecificUser() {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "9876543210/subscribers"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "9876543210/subscribers"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("subscribe-list"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GeneralActionTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GeneralActionTemplateTest.java
@@ -27,7 +27,7 @@ public class GeneralActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void like() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/og.likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/og.likes"))
 			.andExpect(method(POST))
 			.andExpect(content().string("object=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -39,7 +39,7 @@ public class GeneralActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void like_withPrivacy() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/og.likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/og.likes"))
 			.andExpect(method(POST))
 			.andExpect(content().string("privacy=%7B%22value%22%3A%22SELF%22%7D&object=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -51,7 +51,7 @@ public class GeneralActionTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void follow() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/og.follows"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/og.follows"))
 			.andExpect(method(POST))
 			.andExpect(content().string("profile=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GroupTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GroupTemplateTest.java
@@ -31,7 +31,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGroup() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/213106022036379"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "213106022036379"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group"), MediaType.APPLICATION_JSON));
@@ -50,7 +50,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMembers() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/213106022036379/members"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "213106022036379/members"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group-members"), MediaType.APPLICATION_JSON));
@@ -74,7 +74,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMemberProfiles() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/213106022036379/members?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "213106022036379/members?fields=id%2Cname%2Cfirst_name%2Clast_name%2Cgender%2Clocale%2Ceducation%2Cwork%2Cemail%2Cthird_party_id%2Clink%2Ctimezone%2Cupdated_time%2Cverified%2Cabout%2Cbio%2Cbirthday%2Clocation%2Chometown%2Cinterested_in%2Creligion%2Cpolitical%2Cquotes%2Crelationship_status%2Csignificant_other%2Cwebsite"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group-members"), MediaType.APPLICATION_JSON));
@@ -84,7 +84,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMemberships_currentUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/groups"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/groups"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group-memberships"), MediaType.APPLICATION_JSON));
@@ -94,7 +94,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMemberships_specificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/12345678/groups"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "12345678/groups"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group-memberships"), MediaType.APPLICATION_JSON));
@@ -104,7 +104,7 @@ public class GroupTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void search() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/search?offset=0&limit=25&q=Spring+User+Group&type=group&fields=owner%2Cname%2Cdescription%2Cprivacy%2Cicon%2Cupdated_time%2Cemail"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "search?offset=0&limit=25&q=Spring+User+Group&type=group&fields=owner%2Cname%2Cdescription%2Cprivacy%2Cicon%2Cupdated_time%2Cemail"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("group-list"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
@@ -35,7 +35,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void like() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/likes"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{}", MediaType.APPLICATION_JSON));			
@@ -47,7 +47,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	public void like_objectAccessNotPermitted() {
 		HttpHeaders responseHeaders = new HttpHeaders();
 		responseHeaders.setContentType(MediaType.APPLICATION_JSON);
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/likes"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withStatus(HttpStatus.FORBIDDEN).body(jsonResource("error-permission")).contentType(MediaType.APPLICATION_JSON));
@@ -61,7 +61,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void unlike() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456/likes"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456/likes"))
 			.andExpect(method(POST))
 			.andExpect(content().string("method=delete"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -77,7 +77,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getLikes() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/12345678/likes")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "12345678/likes")).andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-references"), MediaType.APPLICATION_JSON));
 		PagedList<Reference> likes = facebook.likeOperations().getLikes("12345678");
@@ -92,7 +92,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getPagesLiked();
@@ -101,7 +101,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getPagesLiked(PAGING_PARAMS_25_50);
@@ -115,7 +115,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getPagesLiked_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getPagesLiked("123456789");
@@ -124,7 +124,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getPagesLiked("123456789", PAGING_PARAMS_25_50);
@@ -138,7 +138,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getBooks();
@@ -147,7 +147,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getBooks_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getBooks(PAGING_PARAMS_25_50);
@@ -161,7 +161,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getBooks("123456789");
@@ -170,7 +170,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getBooks("123456789", PAGING_PARAMS_25_50);
@@ -184,7 +184,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMovies();
@@ -193,7 +193,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMovies(PAGING_PARAMS_25_50);
@@ -207,7 +207,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMovies_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMovies("123456789");
@@ -216,7 +216,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMovies("123456789", PAGING_PARAMS_25_50);
@@ -230,7 +230,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMusic() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMusic();
@@ -239,7 +239,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMusic(PAGING_PARAMS_25_50);
@@ -253,7 +253,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMusic_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMusic("123456789");
@@ -262,7 +262,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getMusic("123456789", PAGING_PARAMS_25_50);
@@ -276,7 +276,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getTelevision() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getTelevision();
@@ -285,7 +285,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getTelevision(PAGING_PARAMS_25_50);
@@ -299,7 +299,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getTelevision_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getTelevision("123456789");
@@ -308,7 +308,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getTelevision_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getTelevision("123456789", PAGING_PARAMS_25_50);
@@ -322,7 +322,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getActivities() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/activities?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/activities?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getActivities();
@@ -331,7 +331,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getActivities_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/activities?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/activities?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getActivities(PAGING_PARAMS_25_50);
@@ -345,7 +345,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getActivities_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/activities?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/activities?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getActivities("123456789");
@@ -354,7 +354,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getActivities_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/activities?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/activities?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getActivities("123456789", PAGING_PARAMS_25_50);
@@ -368,7 +368,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getInterests() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/interests?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/interests?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getInterests();
@@ -377,7 +377,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getInterests_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/interests?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/interests?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getInterests(PAGING_PARAMS_25_50);
@@ -391,7 +391,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getInterests_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/interests?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/interests?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getInterests("123456789");
@@ -400,7 +400,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getInterests_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/interests?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/interests?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getInterests("123456789", PAGING_PARAMS_25_50);
@@ -414,7 +414,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getGames();
@@ -423,7 +423,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getGames(PAGING_PARAMS_25_50);
@@ -437,7 +437,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getGames("123456789");
@@ -446,7 +446,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getGames_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")).andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
 		List<Page> likes = facebook.likeOperations().getGames("123456789", PAGING_PARAMS_25_50);

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
@@ -33,7 +33,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAlbums() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/albums?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/albums?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("albums"), MediaType.APPLICATION_JSON));
@@ -48,7 +48,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAlbums_forSpecificUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/albums?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "192837465/albums?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("albums"), MediaType.APPLICATION_JSON));
@@ -59,7 +59,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getAlbums_forSpecificUser_unauthorized() {
 		try {
-			unauthorizedMockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/albums?offset=0&limit=25"))
+			unauthorizedMockServer.expect(requestTo(getGraphApiUrl() + "192837465/albums?offset=0&limit=25"))
 				.andExpect(method(GET))
 				.andRespond(withSuccess(jsonResource("albums"), MediaType.APPLICATION_JSON));
 			unauthorizedFacebook.mediaOperations().getAlbums("192837465");
@@ -70,7 +70,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAlbum() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10151447271460580"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10151447271460580"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("album"), MediaType.APPLICATION_JSON));
@@ -80,7 +80,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAlbumWithUnknownPrivacy() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10151447271460580"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10151447271460580"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("album-with-unknown-privacy"), MediaType.APPLICATION_JSON));
@@ -90,7 +90,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getAlbumWithUnknownType() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10151447271460580"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10151447271460580"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("album-with-unknown-type"), MediaType.APPLICATION_JSON));
@@ -100,7 +100,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPhotos() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10151447271460580/photos?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10151447271460580/photos?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("photos"), MediaType.APPLICATION_JSON));
@@ -112,7 +112,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getPhotos_unauthorized() {
 		try {
-			unauthorizedMockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/photos?offset=0&limit=25"))
+			unauthorizedMockServer.expect(requestTo(getGraphApiUrl() + "192837465/photos?offset=0&limit=25"))
 				.andExpect(method(GET))
 				.andRespond(withSuccess(jsonResource("photos"), MediaType.APPLICATION_JSON));
 			unauthorizedFacebook.mediaOperations().getPhotos("192837465");
@@ -123,7 +123,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPhoto() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/10150447271355581"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "10150447271355581"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("photo"), MediaType.APPLICATION_JSON));
@@ -133,7 +133,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getPhoto_unauthorized() {
 		try {
-			unauthorizedMockServer.expect(requestTo("https://graph.facebook.com/v2.2/10150447271355581"))
+			unauthorizedMockServer.expect(requestTo(getGraphApiUrl() + "10150447271355581"))
 				.andExpect(method(GET))
 				.andRespond(withSuccess(jsonResource("photo"), MediaType.APPLICATION_JSON));
 			unauthorizedFacebook.mediaOperations().getPhoto("10150447271355581");
@@ -145,7 +145,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void postPhoto_noCaption() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -162,7 +162,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void postPhoto_withCaption() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -179,7 +179,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void postPhoto_ToAlbumNoCaption() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "192837465/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -196,7 +196,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void postPhoto_ToAlbumWithCaption() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "192837465/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -213,7 +213,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getVideos() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/videos?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/videos?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("videos"), MediaType.APPLICATION_JSON));
@@ -228,7 +228,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getVideos_forSpecificOwner() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/100001387295207/videos?offset=0&limit=25"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "100001387295207/videos?offset=0&limit=25"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("videos"), MediaType.APPLICATION_JSON));
@@ -243,7 +243,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getVideo_preOctober2012() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/161500020572907"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "161500020572907"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("video_preOct2012"), MediaType.APPLICATION_JSON));
@@ -253,7 +253,7 @@ public class MediaTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getVideo() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/161500020572907"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "161500020572907"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("video"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MusicActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MusicActionsTemplateTest.java
@@ -27,7 +27,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void listenToSong() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.listens"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.listens"))
 			.andExpect(method(POST))
 			.andExpect(content().string("song=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -39,7 +39,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void listenToAlbum() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.listens"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.listens"))
 			.andExpect(method(POST))
 			.andExpect(content().string("album=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -51,7 +51,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void listenToRadioStation() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.listens"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.listens"))
 			.andExpect(method(POST))
 			.andExpect(content().string("radio_station=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -63,7 +63,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void listenToMusician() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.listens"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.listens"))
 			.andExpect(method(POST))
 			.andExpect(content().string("musician=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -75,7 +75,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void listenToPlaylist() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.listens"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.listens"))
 			.andExpect(method(POST))
 			.andExpect(content().string("playlist=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -87,7 +87,7 @@ public class MusicActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void createPlaylist() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/music.playlists"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/music.playlists"))
 			.andExpect(method(POST))
 			.andExpect(content().string("playlist=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/OpenGraphTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/OpenGraphTemplateTest.java
@@ -37,7 +37,7 @@ public class OpenGraphTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void publishAction() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/socialshowcase:ding"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/socialshowcase:ding"))
 			.andExpect(method(POST))
 			.andExpect(content().string("thing=http%3A%2F%2Fwww.springsource.org%2Fspringsocial"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -38,7 +38,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void getPage_organization() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/140804655931206"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "140804655931206"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("organization-page"), MediaType.APPLICATION_JSON));
@@ -62,7 +62,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void getPage_product() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/21278871488"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "21278871488"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("product-page"), MediaType.APPLICATION_JSON));
@@ -91,7 +91,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void getPage_place() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/150263434985489"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "150263434985489"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("place-page"), MediaType.APPLICATION_JSON));
@@ -132,7 +132,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void getPage_place_with_hours() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/220817147947513"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "220817147947513"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("place-with-hours-page"), MediaType.APPLICATION_JSON));
@@ -175,7 +175,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPage_application() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/140372495981006"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "140372495981006"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("application-page"), MediaType.APPLICATION_JSON));
@@ -192,7 +192,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void getPage_withExtraData() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/11803178355"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "11803178355"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("page-with-extra-data"), MediaType.APPLICATION_JSON));
@@ -254,7 +254,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	public void post_message() throws Exception {
 		expectFetchAccounts();
 		String requestBody = "message=Hello+Facebook+World&access_token=pageAccessToken";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/987654321/feed"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "987654321/feed"))
 				.andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
@@ -278,7 +278,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	public void postLink() throws Exception {
 		expectFetchAccounts();
 		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World&access_token=pageAccessToken";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/987654321/feed")).andExpect(method(POST))
+		mockServer.expect(requestTo(getGraphApiUrl() + "987654321/feed")).andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
@@ -291,7 +291,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	public void postLink_withPicture() throws Exception {
 		expectFetchAccounts();
 		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World&access_token=pageAccessToken&picture=somePic";
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/987654321/feed")).andExpect(method(POST))
+		mockServer.expect(requestTo(getGraphApiUrl() + "987654321/feed")).andExpect(method(POST))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
@@ -316,7 +316,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void postPhoto_noCaption() {
 		expectFetchAccounts();
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "192837465/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -334,7 +334,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void postPhoto_withCaption() {
 		expectFetchAccounts();
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/192837465/photos"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "192837465/photos"))
 			.andExpect(method(POST))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess("{\"id\":\"12345\"}", MediaType.APPLICATION_JSON));
@@ -351,7 +351,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void search() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/search?q=coffee&type=place&center=33.050278%2C-96.745833&distance=5280"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "search?q=coffee&type=place&center=33.050278%2C-96.745833&distance=5280"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("places-list"), MediaType.APPLICATION_JSON));
@@ -387,7 +387,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 	// private helpers
 	
 	private void expectFetchAccounts() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/accounts"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/accounts"))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("accounts"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/UserTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/UserTemplateTest.java
@@ -45,7 +45,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getUserProfile_currentUser() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("full-profile"), MediaType.APPLICATION_JSON));
@@ -109,7 +109,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_specificUserByUserId() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile"), MediaType.APPLICATION_JSON));
@@ -120,7 +120,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_specificUserByUserId_noMiddleName() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-no-middle-name"), MediaType.APPLICATION_JSON));
@@ -131,7 +131,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getUserProfile_specificUserByUserId_withRealTimezone() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-with-timezone"), MediaType.APPLICATION_JSON));
@@ -143,7 +143,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getUserProfile_withAgeRange_13_17() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-with-age-range-13-17"), MediaType.APPLICATION_JSON));
@@ -156,7 +156,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_withAgeRange_18_20() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-with-age-range-18-20"), MediaType.APPLICATION_JSON));
@@ -169,7 +169,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_withAgeRange_21_plus() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-with-age-range-21-plus"), MediaType.APPLICATION_JSON));
@@ -182,7 +182,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_withAgeRange_unknown() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile-with-age-range-unknown"), MediaType.APPLICATION_JSON));
@@ -195,7 +195,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfile_withAgeRange_null() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/123456789?fields=" + PROFILE_FIELDS))
+		mockServer.expect(requestTo(getGraphApiUrl() + "123456789?fields=" + PROFILE_FIELDS))
 				.andExpect(method(GET))
 				.andExpect(header("Authorization", "OAuth someAccessToken"))
 				.andRespond(withSuccess(jsonResource("minimal-profile"), MediaType.APPLICATION_JSON));
@@ -208,7 +208,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfileImage() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/picture?type=normal"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/picture?type=normal"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(new ClassPathResource("tinyrod.jpg", getClass()), MediaType.IMAGE_JPEG));
@@ -224,7 +224,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserProfileImage_specificUserByUserId() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/1234567/picture?type=normal"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1234567/picture?type=normal"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(new ClassPathResource("tinyrod.jpg", getClass()), MediaType.IMAGE_JPEG));
@@ -235,7 +235,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getUserProfileImage_specificUserAndType() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/1234567/picture?type=large"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "1234567/picture?type=large"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(new ClassPathResource("tinyrod.jpg", getClass()), MediaType.IMAGE_JPEG));
@@ -251,7 +251,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getUserPermissions() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/permissions"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/permissions"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-permissions"), MediaType.APPLICATION_JSON));
@@ -270,7 +270,7 @@ public class UserTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void search() {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/search?q=Michael+Scott&type=user"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "search?q=Michael+Scott&type=user"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("user-references"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VideoActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VideoActionsTemplateTest.java
@@ -27,7 +27,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void watchMovie() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.watches"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.watches"))
 			.andExpect(method(POST))
 			.andExpect(content().string("movie=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -39,7 +39,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void watchTvShow() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.watches"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.watches"))
 			.andExpect(method(POST))
 			.andExpect(content().string("tv_show=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -51,7 +51,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void watchTvEpisode() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.watches"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.watches"))
 			.andExpect(method(POST))
 			.andExpect(content().string("tv_episode=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -63,7 +63,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void watchEpisode() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.watches"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.watches"))
 			.andExpect(method(POST))
 			.andExpect(content().string("episode=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -75,7 +75,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void watchVideo() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.watches"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.watches"))
 			.andExpect(method(POST))
 			.andExpect(content().string("video=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -87,7 +87,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void rateMovie() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.rates"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.rates"))
 			.andExpect(method(POST))
 			.andExpect(content().string("movie=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&rating%3Avalue=3.2&rating%3Ascale=5"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -99,7 +99,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void rateTvShow() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.rates"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.rates"))
 			.andExpect(method(POST))
 			.andExpect(content().string("tv_show=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&rating%3Avalue=3.2&rating%3Ascale=5"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -111,7 +111,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void rateEpisode() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.rates"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.rates"))
 			.andExpect(method(POST))
 			.andExpect(content().string("episode=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&rating%3Avalue=3.2&rating%3Ascale=5"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -123,7 +123,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void rateVideo() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.rates"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.rates"))
 			.andExpect(method(POST))
 			.andExpect(content().string("other=http%3A%2F%2Fsamples.ogp.me%2F226075010839791&rating%3Avalue=3.2&rating%3Ascale=5"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -135,7 +135,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void wantsToWatchMovie() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.wants_to_watch"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.wants_to_watch"))
 			.andExpect(method(POST))
 			.andExpect(content().string("movie=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -147,7 +147,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void wantsToWatchTvShow() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.wants_to_watch"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.wants_to_watch"))
 			.andExpect(method(POST))
 			.andExpect(content().string("tv_show=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -159,7 +159,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void wantsToWatchEpisode() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.wants_to_watch"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.wants_to_watch"))
 			.andExpect(method(POST))
 			.andExpect(content().string("episode=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
@@ -171,7 +171,7 @@ public class VideoActionsTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void wantsToWatchVideo() throws Exception {
-		mockServer.expect(requestTo("https://graph.facebook.com/v2.2/me/video.wants_to_watch"))
+		mockServer.expect(requestTo(getGraphApiUrl() + "me/video.wants_to_watch"))
 			.andExpect(method(POST))
 			.andExpect(content().string("other=http%3A%2F%2Fsamples.ogp.me%2F226075010839791"))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/connect/FacebookAdapterTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/connect/FacebookAdapterTest.java
@@ -52,7 +52,7 @@ public class FacebookAdapterTest {
 		TestConnectionValues connectionValues = new TestConnectionValues();
 		apiAdapter.setConnectionValues(facebook, connectionValues);
 		assertEquals("Craig Walls", connectionValues.getDisplayName());
-		assertEquals("https://graph.facebook.com/v2.2/12345678/picture", connectionValues.getImageUrl());
+		assertEquals("https://graph.facebook.com/12345678/picture", connectionValues.getImageUrl());
 		assertEquals("https://www.facebook.com/app_scoped_user_id/12345678/", connectionValues.getProfileUrl());
 		assertEquals("12345678", connectionValues.getProviderUserId());
 	}


### PR DESCRIPTION
Allowing for user flexibility with regards to the graph version to use.  This will hopefully mean that in the future users can upgrade to new versions at their own risk. 