### PR TITLE
https://jira.spring.io/browse/SOCIALFB-166

### DIFF
--- a/README
+++ b/README
@@ -24,5 +24,6 @@ To build the JavaDoc, do the following from within the root directory:
 
  ./gradlew :docs:api
 
-The result will be available in 'docs/build/api'.
+The result will be available in 'docs/build/api'. Test
 ===============================================================================
+

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -138,6 +138,6 @@ class EventTemplate implements EventOperations {
 		return graphApi.fetchConnections(userId, "events/" + status, Invitation.class, parameters);
 	}
 	
-	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "location", "name", 
-			"owner", "parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time", "venue" };
+	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", 
+			"owner", "parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time"};
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
@@ -108,7 +108,7 @@ class PageTemplate implements PageOperations {
 	
 	private Map<String, Account> accountCache = new HashMap<String, Account>();
 	
-	private String getPageAccessToken(String pageId) {
+	public  String getPageAccessToken(String pageId) {
 		Account account = getAccount(pageId);
 		if(account == null) {
 			throw new PageAdministrationException(pageId);


### PR DESCRIPTION
Changes for https://jira.spring.io/browse/SOCIALFB-166

1. PageTemplate has a getPageAccessToken() method.
2.All page operations require this Page_access_token in the header getPageAccessToken
3. If extending PageTemplate, then any operation would need access to this getPageAccessToken, otherwise, that class would need to duplicate and maintain an account_cache in it.
4. So, making getPageAccessToken() method public so extended Child class's can use this for further Page Template Operations.
5. Ran unit tests and integration tests to ensure that nothing is broken. 
6. Performed page operations to test the functionality.