### PR TITLE
Update dialog URLs to explicitly use v2.3.

### DIFF
--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
@@ -131,7 +131,7 @@ public class CanvasSignInController {
 					String clientId = (String) model.get("clientId");
 					String canvasPage = (String) model.get("canvasPage");
 					String scope = (String) model.get("scope");
-					String redirectUrl = "https://www.facebook.com/v1.0/dialog/oauth?client_id=" + clientId + "&redirect_uri=" + canvasPage;
+					String redirectUrl = "https://www.facebook.com/v2.3/dialog/oauth?client_id=" + clientId + "&redirect_uri=" + canvasPage;
 					if (scope != null) {
 						redirectUrl += "&scope=" + formEncode(scope);
 					}

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
@@ -43,7 +43,7 @@ public class FacebookServiceProvider extends AbstractOAuth2ServiceProvider<Faceb
 	
 	private static OAuth2Template getOAuth2Template(String appId, String appSecret) {
 		OAuth2Template oAuth2Template = new OAuth2Template(appId, appSecret,
-				"https://www.facebook.com/dialog/oauth", 
+				"https://www.facebook.com/v2.3/dialog/oauth",
 				GraphApi.GRAPH_API_URL + "oauth/access_token");
 		oAuth2Template.setUseParametersForClientAuthentication(true);
 		return oAuth2Template;


### PR DESCRIPTION
This is missing from the RC1 and is the same operation as with eb98bbeb1e58afeba6de36b307573103e87c8143