### PR TITLE
https://github.com/spring-projects/spring-social-facebook/issues/143

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Event.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Event.java
@@ -33,8 +33,6 @@ public class Event extends FacebookObject {
 	private Date endTime;
 
 	private boolean isDateOnly;
-	
-	private String location;
 
 	private String name;
 	
@@ -52,8 +50,8 @@ public class Event extends FacebookObject {
 	
 	private Date updatedTime;
 	
-	private Location venue;
-	
+	private Place place;
+		
 	public String getId() {
 		return id;
 	}
@@ -86,10 +84,6 @@ public class Event extends FacebookObject {
 		return endTime;
 	}
 
-	public String getLocation() {
-		return location;
-	}
-	
 	public String getTicketUri() {
 		return ticketUri;
 	}
@@ -110,10 +104,13 @@ public class Event extends FacebookObject {
 		return parentGroup;
 	}
 	
-	public Location getVenue() {
-		return venue;
+	public Place getPlace() {
+		return place;
 	}
-	
+
+	public void setPlace(Place place) {
+		this.place = place;
+	}
+
 	public static enum Privacy { OPEN, SECRET, CLOSED, FRIENDS }
-	
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Place.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Place.java
@@ -1,0 +1,27 @@
+package org.springframework.social.facebook.api;
+
+public class Place {
+
+	private String id;
+	private Location location; 
+	private String name;
+	
+	public String getId() {
+		return id;
+	}
+	public void setId(String id) {
+		this.id = id;
+	}
+	public String getName() {
+		return name;
+	}
+	public void setName(String name) {
+		this.name = name;
+	}
+	public Location getLocation() {
+		return location;
+	}
+	public void setLocation(Location location) {
+		this.location = location;
+	}
+}

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -139,5 +139,5 @@ class EventTemplate implements EventOperations {
 	}
 	
 	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", "owner", 
-		"parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time"};
+		"parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time", "place"};
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -138,6 +138,6 @@ class EventTemplate implements EventOperations {
 		return graphApi.fetchConnections(userId, "events/" + status, Invitation.class, parameters);
 	}
 	
-	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", 
-			"owner", "parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time"};
+	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", "owner", 
+		"parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time"};
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -138,6 +138,6 @@ class EventTemplate implements EventOperations {
 		return graphApi.fetchConnections(userId, "events/" + status, Invitation.class, parameters);
 	}
 	
-	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "location", "name", 
-			"owner", "parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time", "venue" };
+	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", 
+			"owner", "parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time"};
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
@@ -108,7 +108,7 @@ class PageTemplate implements PageOperations {
 	
 	private Map<String, Account> accountCache = new HashMap<String, Account>();
 	
-	public  String getPageAccessToken(String pageId) {
+	private  String getPageAccessToken(String pageId) {
 		Account account = getAccount(pageId);
 		if(account == null) {
 			throw new PageAdministrationException(pageId);

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
@@ -108,7 +108,7 @@ class PageTemplate implements PageOperations {
 	
 	private Map<String, Account> accountCache = new HashMap<String, Account>();
 	
-	private  String getPageAccessToken(String pageId) {
+	private String getPageAccessToken(String pageId) {
 		Account account = getAccount(pageId);
 		if(account == null) {
 			throw new PageAdministrationException(pageId);

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
@@ -108,7 +108,7 @@ class PageTemplate implements PageOperations {
 	
 	private Map<String, Account> accountCache = new HashMap<String, Account>();
 	
-	private String getPageAccessToken(String pageId) {
+	public  String getPageAccessToken(String pageId) {
 		Account account = getAccount(pageId);
 		if(account == null) {
 			throw new PageAdministrationException(pageId);

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
@@ -80,7 +80,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getEvent() {
 		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cplace")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("simple-event"), MediaType.APPLICATION_JSON));
@@ -91,7 +91,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getEvent_withFriendPrivacyLevel() {
 		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cplace")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("simple-event-friend-privacy"), MediaType.APPLICATION_JSON));
@@ -102,7 +102,7 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	@Test
 	public void getEvent_withLocationAndDescription() {
 		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cplace")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("full-event"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
@@ -79,8 +79,8 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getEvent() {
-		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue")))
+		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("simple-event"), MediaType.APPLICATION_JSON));
@@ -90,8 +90,8 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getEvent_withFriendPrivacyLevel() {
-		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue")))
+		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("simple-event-friend-privacy"), MediaType.APPLICATION_JSON));
@@ -101,8 +101,8 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getEvent_withLocationAndDescription() {
-		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Clocation%2Cname"
-				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time%2Cvenue")))
+		mockServer.expect(requestTo(fbUrl("193482154020832?fields=id%2Ccover%2Cdescription%2Cend_time%2Cis_date_only%2Cname"
+				+ "%2Cowner%2Cparent_group%2Cprivacy%2Cstart_time%2Cticket_uri%2Ctimezone%2Cupdated_time")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("full-event"), MediaType.APPLICATION_JSON));
@@ -116,7 +116,6 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(toDate("2011-03-30T17:30:00+0000"), event.getEndTime());
 		assertEquals(toDate("2011-03-30T14:38:40+0000"), event.getUpdatedTime());
 		assertEquals("Bring your best parachute pants!", event.getDescription());
-		assertEquals("2400 Dunlavy Dr, Denton, TX", event.getLocation());
 	}
 	
 	@Test
@@ -224,7 +223,6 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(1, results.size());
 		assertEquals("196119297091135", results.get(0).getId());
 		assertEquals("FLUG (Florida Local Users Group) Spring User Conference", results.get(0).getName());
-		assertEquals("Radisson Resort at the Port", results.get(0).getLocation());
 		assertEquals(toDate("2011-06-01T08:00:00+0000"), results.get(0).getStartTime());
 		assertEquals(toDate("2011-06-03T16:00:00+0000"), results.get(0).getEndTime());
 	}
@@ -239,7 +237,6 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(2, events.size());
 		assertEquals("188420717869087", events.get(0).getEventId());
 		assertEquals("Afternoon naptime", events.get(0).getName());
-		assertEquals("On the couch", events.get(0).getLocation());
 		// Facebook event times don't have a timezone component, so they end up parsed as in +0000
 		// Unfortunately, this is probably not the actual time of the event.
 		assertEquals(toDate("2011-03-26T14:00:00+0000"), events.get(0).getStartTime());
@@ -247,7 +244,6 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(RsvpStatus.ATTENDING, events.get(0).getRsvpStatus());
 		assertEquals("188420717869780", events.get(1).getEventId());
 		assertEquals("Mow the lawn", events.get(1).getName());
-		assertNull(events.get(1).getLocation());
 		assertEquals(toDate("2011-03-26T15:00:00+0000"), events.get(1).getStartTime());
 		assertEquals(toDate("2011-03-26T16:00:00+0000"), events.get(1).getEndTime());
 		assertEquals(RsvpStatus.NOT_REPLIED, events.get(1).getRsvpStatus());
@@ -262,17 +258,6 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(toDate("2011-03-30T14:30:00+0000"), event.getStartTime());
 		assertEquals(toDate("2011-03-30T17:30:00+0000"), event.getEndTime());
 		assertEquals(toDate("2011-03-30T14:30:28+0000"), event.getUpdatedTime());
-		Location venue = event.getVenue();
-		assertEquals("215524685134868", venue.getId());
-		assertEquals("Fort Worth", venue.getCity());
-		assertEquals("United States", venue.getCountry());
-		assertEquals("TX", venue.getState());
-		assertEquals("921 Henderson St", venue.getStreet());
-		assertEquals("76102", venue.getZip());
-		assertEquals(32.7493792167, venue.getLatitude(), 0.00001);
-		assertEquals(-97.3371771801, venue.getLongitude(), 0.00001);
-		assertEquals("Some call it spin class", event.getDescription());
-		assertEquals("Walgreens", event.getLocation());
 		assertTrue(event.isDateOnly());
 		CoverPhoto cover = event.getCover();
 		assertEquals("14639096", cover.getId());

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
@@ -258,6 +258,15 @@ public class EventTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(toDate("2011-03-30T14:30:00+0000"), event.getStartTime());
 		assertEquals(toDate("2011-03-30T17:30:00+0000"), event.getEndTime());
 		assertEquals(toDate("2011-03-30T14:30:28+0000"), event.getUpdatedTime());
+		Location venue = event.getPlace().getLocation();
+		assertEquals("142223762504319",  event.getPlace().getId());
+		assertEquals("Lake Buena Vista", venue.getCity());
+		assertEquals("United States", venue.getCountry());
+		assertEquals("FL", venue.getState());
+		assertEquals("1850 Animation Way", venue.getStreet());
+		assertEquals("32830", venue.getZip());
+		assertEquals("Disney's Art of Animation Resort", event.getPlace().getName());
+		assertEquals("Some call it spin class", event.getDescription());
 		assertTrue(event.isDateOnly());
 		CoverPhoto cover = event.getCover();
 		assertEquals("14639096", cover.getId());

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/simple-event-friend-privacy.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/simple-event-friend-privacy.json
@@ -18,15 +18,18 @@
     "updated_time":"2011-03-30T14:30:28+0000",
     "location": "Walgreens",
     "description": "Some call it spin class",
-    "venue": {
-      "id": "215524685134868", 
-      "city": "Fort Worth", 
-      "country": "United States", 
-      "latitude": 32.7493792167, 
-      "longitude": -97.3371771801, 
-      "state": "TX", 
-      "street": "921 Henderson St", 
-      "zip": "76102"
-    },
+    "place": {
+        "id": "142223762504319",
+        "location": {
+          "city": "Lake Buena Vista",
+          "country": "United States",
+          "latitude": 28.350102,
+          "longitude": -81.548863,
+          "state": "FL",
+          "street": "1850 Animation Way",
+          "zip": "32830"
+        },
+        "name": "Disney's Art of Animation Resort"
+      },
     "is_date_only": true
 }

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/simple-event.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/simple-event.json
@@ -18,16 +18,19 @@
     "updated_time":"2011-03-30T14:30:28+0000",
     "location": "Walgreens",
     "description": "Some call it spin class",
-    "venue": {
-      "id": "215524685134868", 
-      "city": "Fort Worth", 
-      "country": "United States", 
-      "latitude": 32.7493792167, 
-      "longitude": -97.3371771801, 
-      "state": "TX", 
-      "street": "921 Henderson St", 
-      "zip": "76102"
-    },
+    "place": {
+        "id": "142223762504319",
+        "location": {
+          "city": "Lake Buena Vista",
+          "country": "United States",
+          "latitude": 28.350102,
+          "longitude": -81.548863,
+          "state": "FL",
+          "street": "1850 Animation Way",
+          "zip": "32830"
+        },
+        "name": "Disney's Art of Animation Resort"
+      },
     "is_date_only": true
 }
 


### PR DESCRIPTION
https://github.com/spring-projects/spring-social-facebook/issues/143
Removing location and venue from Event Operations. 
Venue and location are deprecated as per v2.3 https://developers.facebook.com/docs/apps/changelog