### PR TITLE
Fix could not read JSON error.

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/WorkEntryMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/WorkEntryMixin.java
@@ -49,7 +49,7 @@ abstract class WorkEntryMixin extends FacebookObjectMixin {
 	@JsonProperty("start_date")
 	String startDate;
 	
-	
+	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static abstract class ProjectMixin {
 		
 		@JsonProperty("description")


### PR DESCRIPTION
When I used 2.0.0.M1 spring-social-facebook, following exception occured.  
```
org.springframework.http.converter.HttpMessageNotReadableException: Could not read JSON: Unrecognized field "id" (class org.springframework.social.facebook.api.WorkEntry$Project), not marked as ignorable (4 known properties: , "end_date", "start_date", "description", "with"])
```
WorkEntry.Project is not marked as json ignogre unknown field.