### PR TITLE
https://github.com/spring-projects/spring-social-facebook/issues/146

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
@@ -117,7 +117,7 @@ class FriendTemplate implements FriendOperations {
 
 	public PagedList<UserTaggableFriend> getTaggableFriends() {
 		return graphApi.fetchConnections("me", "taggable_friends", UserTaggableFriend.class, 
-				"id", "name" ,"picture", "first_name", "last_name", "middle_name");
+				"id", "name" ,"picture", "first_name", "last_name", "middle_name");  
 	}
 	
 	private static final String FULL_PROFILE_FIELDS = "id,name,first_name,last_name,gender,locale,education,work,email,third_party_id,link,timezone,updated_time,verified,about,bio,birthday,location,hometown,interested_in,religion,political,quotes,relationship_status,significant_other,website";

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
@@ -117,7 +117,7 @@ class FriendTemplate implements FriendOperations {
 
 	public PagedList<UserTaggableFriend> getTaggableFriends() {
 		return graphApi.fetchConnections("me", "taggable_friends", UserTaggableFriend.class, 
-				"id", "name" ,"picturefields(is_silhouette,url,width,height)", "first_name", "last_name", "middle_name");
+				"id", "name" ,"picture", "first_name", "last_name", "middle_name");
 	}
 	
 	private static final String FULL_PROFILE_FIELDS = "id,name,first_name,last_name,gender,locale,education,work,email,third_party_id,link,timezone,updated_time,verified,about,bio,birthday,location,hometown,interested_in,religion,political,quotes,relationship_status,significant_other,website";

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
@@ -137,7 +137,7 @@ public class FriendTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getTaggableFriends() throws Exception {
-		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/taggable_friends?fields=id%2Cname%2Cpicturefields%28is_silhouette%2Curl%2Cwidth%2Cheight%29%2Cfirst_name%2Clast_name%2Cmiddle_name"))
+		mockServer.expect(requestTo(GraphApi.GRAPH_API_URL + "me/taggable_friends?fields=id%2Cname%2Cpicture%2Cfirst_name%2Clast_name%2Cmiddle_name"))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("taggable_friends"), MediaType.APPLICATION_JSON));


### PR DESCRIPTION
1. Removing picturefields from the call to taggable_friends. Went through https://developers.facebook.com/docs/graph-api/reference/user-taggable-friend/
2.  Added picture as the request to taggable_friends
3. Updated Unit tests accordingly.
4. Ran the unit-tests and also compared the fields to graph API explorer.