### PR TITLE
Fix MappingInstantiationException for no default constructor

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
@@ -28,7 +28,12 @@ public class Reference extends FacebookObject implements Serializable {
 
 	private final String name;
 
-	public Reference(String id) {
+    @SuppressWarnings("unused")
+    private Reference() {
+        this(null, null);
+    }
+
+    public Reference(String id) {
 		this(id, null);
 	}
 

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
@@ -28,12 +28,12 @@ public class Reference extends FacebookObject implements Serializable {
 
 	private final String name;
 
-    @SuppressWarnings("unused")
-    private Reference() {
-        this(null, null);
-    }
+    	@SuppressWarnings("unused")
+    	private Reference() {
+        	this(null, null);
+    	}
 
-    public Reference(String id) {
+    	public Reference(String id) {
 		this(id, null);
 	}
 


### PR DESCRIPTION
This fixes NO_CONSTRUCTOR issue encountered during `Reference` instantiation

	2:34:22:629 DEBUG o.s.w.s.FrameworkServlet.processRequest Message=Could not complete request
	org.springframework.data.mapping.model.MappingInstantiationException: Failed to instantiate org.springframework.social.facebook.api.Reference using constructor NO_CONSTRUCTOR with arguments 
		at org.springframework.data.convert.ReflectionEntityInstantiator.createInstance(ReflectionEntityInstantiator.java:64)
		at org.springframework.data.convert.BytecodeGeneratingEntityInstantiator.createInstance(BytecodeGeneratingEntityInstantiator.java:76)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:250)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:231)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.readCollectionOrArray(MappingMongoConverter.java:903)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.readValue(MappingMongoConverter.java:1164)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.access$200(MappingMongoConverter.java:78)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter$MongoDbPropertyValueProvider.getPropertyValue(MappingMongoConverter.java:1115)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.getValueInternal(MappingMongoConverter.java:866)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter$1.doWithPersistentProperty(MappingMongoConverter.java:281)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter$1.doWithPersistentProperty(MappingMongoConverter.java:269)
		at org.springframework.data.mapping.model.BasicPersistentEntity.doWithProperties(BasicPersistentEntity.java:309)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:269)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:231)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:191)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:187)
		at org.springframework.data.mongodb.core.convert.MappingMongoConverter.read(MappingMongoConverter.java:78)
		at org.springframework.data.mongodb.core.MongoTemplate$ReadDbObjectCallback.doWith(MongoTemplate.java:2191)
		at org.springframework.data.mongodb.core.MongoTemplate.executeFindMultiInternal(MongoTemplate.java:1873)
		at org.springframework.data.mongodb.core.MongoTemplate.doFind(MongoTemplate.java:1696)
		at org.springframework.data.mongodb.core.MongoTemplate.doFind(MongoTemplate.java:1679)
		at org.springframework.data.mongodb.core.MongoTemplate.find(MongoTemplate.java:598)