### PR TITLE
int is to small for facebook video upload limit values #181

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoUploadLimits.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoUploadLimits.java
@@ -21,20 +21,20 @@ package org.springframework.social.facebook.api;
  */
 public class VideoUploadLimits extends FacebookObject {
 
-	private final int length;
+	private final long length;
 	
-	private final int size;
+	private final long size;
 
-	public VideoUploadLimits(int length, int size) {
+	public VideoUploadLimits(long length, long size) {
 		this.length = length;
 		this.size = size;
 	}
 	
-	public int getLength() {
+	public long getLength() {
 		return length;
 	}
 	
-	public int getSize() {
+	public long getSize() {
 		return size;
 	}
 	

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoUploadLimitsMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoUploadLimitsMixin.java
@@ -28,7 +28,7 @@ abstract class VideoUploadLimitsMixin extends FacebookObjectMixin {
 
 	@JsonCreator
 	VideoUploadLimitsMixin(
-			@JsonProperty("length") int length, 
-			@JsonProperty("size") int size) {}
+			@JsonProperty("length") long length, 
+			@JsonProperty("size") long size) {}
 	
 }


### PR DESCRIPTION
https://github.com/spring-projects/spring-social-facebook/issues/181


[2015-12-06 15:40:23.346] boot - 1 ERROR [http-nio-8080-exec-7] --- ProviderSignInController: Exception while completing OAuth 2 connection: 
org.springframework.http.converter.HttpMessageNotReadableException: Could not read document: Numeric value (2505397589) out of range of int
 at [Source: java.io.ByteArrayInputStream@3dcc34d1; line: 1, column: 3034] (through reference chain: org.springframework.social.facebook.api.User["video_upload_limits"]); nested exception is com.fasterxml.jackson.databind.JsonMappingException: Numeric value (2505397589) out of range of int
 at [Source: java.io.ByteArrayInputStream@3dcc34d1; line: 1, column: 3034] (through reference chain: org.springframework.social.facebook.api.User["video_upload_limits"])
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:208) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:200) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.web.client.HttpMessageConverterExtractor.extractData(HttpMessageConverterExtractor.java:95) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:574) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:547) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.web.client.RestTemplate.getForObject(RestTemplate.java:255) ~[spring-web-4.1.8.RELEASE.jar!/:4.1.8.RELEASE]
	at org.springframework.social.facebook.api.impl.FacebookTemplate.fetchObject(FacebookTemplate.java:214) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.facebook.api.impl.FacebookTemplate.fetchObject(FacebookTemplate.java:209) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.facebook.api.impl.UserTemplate.getUserProfile(UserTemplate.java:53) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.facebook.api.impl.UserTemplate.getUserProfile(UserTemplate.java:49) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.facebook.connect.FacebookAdapter.fetchUserProfile(FacebookAdapter.java:51) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.facebook.connect.FacebookAdapter.fetchUserProfile(FacebookAdapter.java:31) ~[spring-social-facebook-2.0.2.RELEASE.jar!/:2.0.2.RELEASE]
	at org.springframework.social.connect.support.AbstractConnection.fetchUserProfile(AbstractConnection.java:111) ~[spring-social-core-1.1.2.RELEASE.jar!/:1.1.2.RELEASE]
