### PR TITLE
Allow profile image dimensions to be specified manually

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
@@ -101,6 +101,16 @@ public interface GraphApi {
 	 */
 	byte[] fetchImage(String objectId, String connectionName, ImageType imageType);	
 
+ 	 /**
+	 * Fetches an image as an array of bytes.
+	 * @param objectId the object ID
+	 * @param connectionName the connection name
+	 * @param width desired width of the image (optional)
+	 * @param height desired height of the image (optional)
+	 * @return an image as an array of bytes.
+	 */
+	byte[] fetchImage(String objectId, String connectionName, Integer width, Integer height);
+
 	/**
 	 * Publishes data to an object's connection.
 	 * Requires appropriate permission to publish to the object connection.

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
@@ -75,6 +75,29 @@ public interface UserOperations {
 	byte[] getUserProfileImage(String userId, ImageType imageType);
 
 	/**
+	 * Retrieves the user's profile image. When height and width are both used,
+	 * the image will be scaled as close to the dimensions as possible and then
+	 * cropped down.
+	 * @param width the desired image width
+	 * @param height the desired image height
+	 * @return an array of bytes containing the user's profile image.
+	 * @throws ApiException if there is an error while communicating with Facebook.
+	 */
+	byte[] getUserProfileImage(Integer width, Integer height);
+
+	/**
+	 * Retrieves the user's profile image. When height and width are both used,
+	 * the image will be scaled as close to the dimensions as possible and then
+	 * cropped down.
+	 * @param userId the Facebook user ID.
+	 * @param width the desired image width
+	 * @param height the desired image height
+	 * @return an array of bytes containing the user's profile image.
+	 * @throws ApiException if there is an error while communicating with Facebook.
+	 */
+	byte[] getUserProfileImage(String userId, Integer width, Integer height);
+
+	/**
 	 * Retrieves a list of permissions that the application has been granted for the authenticated user.
 	 * @return the permissions granted for the user.
 	 * @throws ApiException if there is an error while communicating with Facebook.

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
@@ -267,7 +267,25 @@ public class FacebookTemplate extends AbstractOAuth2ApiBinding implements Facebo
 	}
 
 	public byte[] fetchImage(String objectId, String connectionType, ImageType type) {
-		URI uri = URIBuilder.fromUri(GRAPH_API_URL + objectId + "/" + connectionType + "?type=" + type.toString().toLowerCase()).build();
+		return fetchImage(objectId, connectionType, type, null, null);
+	}
+
+	public byte[] fetchImage(String objectId, String connectionType, Integer width, Integer height) {
+		return fetchImage(objectId, connectionType, null, width, height);
+	}
+
+	private byte[] fetchImage(String objectId, String connectionType, ImageType type, Integer width, Integer height) {
+		URIBuilder uriBuilder = URIBuilder.fromUri(GRAPH_API_URL + objectId + "/" + connectionType);
+		if (type != null) {
+		  uriBuilder.queryParam("type", type.toString().toLowerCase());
+		}
+		if (width != null) {
+			uriBuilder.queryParam("width", width.toString());
+		}
+		if (height != null) {
+			uriBuilder.queryParam("height", height.toString());
+		}
+		URI uri = uriBuilder.build();
 		ResponseEntity<byte[]> response = getRestTemplate().getForEntity(uri, byte[].class);
 		if(response.getStatusCode() == HttpStatus.FOUND) {
 			throw new UnsupportedOperationException("Attempt to fetch image resulted in a redirect which could not be followed. Add Apache HttpComponents HttpClient to the classpath " +

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
@@ -69,6 +69,14 @@ class UserTemplate implements UserOperations {
 		return graphApi.fetchImage(userId, "picture", imageType);
 	}
 
+	public byte[] getUserProfileImage(Integer width, Integer height) {
+		return getUserProfileImage("me", width, height);
+	}
+
+	public byte[] getUserProfileImage(String userId, Integer width, Integer height) {
+		return graphApi.fetchImage(userId, "picture", width, height);
+	}
+
 	public List<Permission> getUserPermissions() {
 		JsonNode responseNode = restTemplate.getForObject(GraphApi.GRAPH_API_URL + "me/permissions", JsonNode.class);
 		return deserializePermissionsNodeToList(responseNode);


### PR DESCRIPTION
This is an accompanying pull request for [SOCIAL-FB146](https://jira.spring.io/browse/SOCIALFB-146). Here is a copy of the description:

The Facebook Graph Edge for profile pictures allows to select from a predefined list of image sizes via the type parameter. In practice, however, these are often too small, especially when a square image is needed (which by default returns a 50x50 image).

Alternatively, the Graph Edge also allows to specify the desired target dimensions via width/height parameters. In this case, the type parameter is ignored. This alternative is currently not available in spring-social-facebook.

Attached is a patch which allows to access this API via UserOperations/UserTemplate.
