### PR TITLE
SOCIALFB-198: Removed or changed deprecated Event Fields (API v2.4 and higher)

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -138,6 +138,6 @@ class EventTemplate implements EventOperations {
 		return graphApi.fetchConnections(userId, "events/" + status, Invitation.class, parameters);
 	}
 	
-	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "is_date_only", "name", "owner", 
-		"parent_group", "privacy", "start_time", "ticket_uri", "timezone", "updated_time", "place"};
+	private static final String[] ALL_FIELDS = { "id", "cover", "description", "end_time", "name", "owner",
+		"parent_group", "type", "start_time", "ticket_uri", "timezone", "updated_time", "place"};
 }


### PR DESCRIPTION
Removed Field "is_date_only" and changed Field "privacy" to "type" fr…om ALL_Fields Array

This is needed due to deprecation in Facebook API v2.4 and higher.
Issue #198