### PR TITLE
Adding Targeting option to choose which audience will see the post

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePostData.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePostData.java
@@ -44,6 +44,8 @@ public class PagePostData {
 	private String placeId;
 	
 	private String picture;
+
+	private Targeting targeting;
 	
 	/**
 	 * Creates a new {@link PagePostData}.
@@ -91,7 +93,7 @@ public class PagePostData {
 		this.placeId = placeId;
 		return this;
 	}
-	
+
 	/**
 	 * @param tags One or more Facebook user IDs to tag in the post. Will be ignored unless a place is specified.
 	 * @return the PagePostData object for additional configuration
@@ -101,6 +103,18 @@ public class PagePostData {
 		return this;
 	}
 
+
+	/**
+	 * @param targeting allow to set a specific target audience to the post. Will be ignored unless a place is specified.
+	 * @return the PagePostData object for additional configuration
+	 */
+	public PagePostData targeting(Targeting targeting) {
+		this.targeting = targeting;
+		return this;
+	}
+
+
+
 	public MultiValueMap<String, Object> toRequestParameters() {
 		MultiValueMap<String, Object> parameters = new LinkedMultiValueMap<String, Object>();
 		if (message != null) { parameters.add("message", message); }
@@ -109,6 +123,8 @@ public class PagePostData {
 		if (caption != null) { parameters.add("caption", caption); }
 		if (description != null) { parameters.add("description", description); }
 		if (picture != null) { parameters.add("picture", picture); }
+
+		if (targeting != null) {parameters.add("targeting", targeting.toString());}
 		if (placeId != null) { 
 			parameters.add("place", placeId);
 			// tags are only allowed if a place is given

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.social.facebook.api;
+
+import org.springframework.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An object which represents a target operation.
+ * Offers a builder-like way of targeting a post to a specific audition.
+ * @author Jorge Vasquez
+ */
+public class Targeting {
+
+    private Post.PrivacyType privacyType = Post.PrivacyType.CUSTOM;
+    private String[] countries;
+    private String[] locales;
+    private String[] regions;
+    private String[] cities;
+    private Map<String, String> attributesMap = new HashMap<String, String>();
+
+
+    public Targeting privacyType(Post.PrivacyType privacyType) {
+        this.privacyType = privacyType;
+        return this;
+    }
+
+    public Targeting countries(String... countries) {
+        this.countries = countries;
+        return this;
+    }
+
+    public Targeting locales(String[] locales) {
+        this.locales = locales;
+        return this;
+    }
+
+    public Targeting regions(String[] regions) {
+        this.regions = regions;
+        return this;
+    }
+
+
+    public Targeting cities(String[] cities) {
+        this.cities = cities;
+        return this;
+    }
+
+    /*
+     * Help us adding attributes not specified in the class
+     */
+    public Targeting addAttributes(String attributeName, String attributeValue){
+        attributesMap.put(attributeName,attributeValue);
+        return this;
+    }
+
+    /*
+     *Creating Json format with all the attributes set with values
+     */
+    @Override
+    public String toString() {
+        StringBuffer privacyBuffer = new StringBuffer();
+        privacyBuffer.append("{'value': '").append(privacyType).append("'");
+
+        if (privacyType == Post.PrivacyType.CUSTOM) {
+
+            if (countries != null) {
+                privacyBuffer.append(",'countries':'").append(StringUtils.arrayToCommaDelimitedString(countries)).append("'");
+            }
+
+            if (locales != null) {
+                privacyBuffer.append(",'locales':'").append(StringUtils.arrayToCommaDelimitedString(locales)).append("'");
+            }
+            if (regions != null) {
+                privacyBuffer.append(",'regions':'").append(StringUtils.arrayToCommaDelimitedString(regions)).append("'");
+            }
+            if (cities != null) {
+                privacyBuffer.append(",'cities':'").append(StringUtils.arrayToCommaDelimitedString(cities)).append("'");
+            }
+
+        }
+        if(!attributesMap.isEmpty()){
+
+            for (Map.Entry<String, String > entry : attributesMap.entrySet()) {
+                privacyBuffer.append(",'"+entry.getKey()+"':'" + entry.getKey() + "'");
+            }
+        }
+        privacyBuffer.append("}");
+        return privacyBuffer.toString();
+    }
+
+}

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
@@ -97,7 +97,7 @@ public class Targeting {
         if(!attributesMap.isEmpty()){
 
             for (Map.Entry<String, String > entry : attributesMap.entrySet()) {
-                privacyBuffer.append(",'"+entry.getKey()+"':'" + entry.getKey() + "'");
+                privacyBuffer.append(",'"+entry.getKey()+"':'" + entry.getValue() + "'");
             }
         }
         privacyBuffer.append("}");

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -223,6 +223,20 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 		mockServer.verify();
 	}
 
+	@Test
+	public void postMessage_withTargetAudience() throws Exception {
+		expectFetchAccounts();
+		String requestBody = "message=Hello+Facebook+World&targeting=%7B%27value%27%3A+%27CUSTOM%27%2C%27countries%27%3A%27PE%27%7D&access_token=pageAccessToken";
+		mockServer.expect(requestTo(fbUrl("987654321/feed")))
+				.andExpect(method(POST))
+				.andExpect(header("Authorization", "OAuth someAccessToken"))
+				.andExpect(content().string(requestBody))
+				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
+
+		assertEquals("123456_78901234", facebook.pageOperations().post(new PagePostData("987654321").message("Hello Facebook World").targeting(new Targeting().countries("PE"))));
+		mockServer.verify();
+	}
+
 	@Test(expected = PageAdministrationException.class)
 	public void postLink_notAdmin() throws Exception {
 		expectFetchAccounts();


### PR DESCRIPTION
Hello, I add the this new feature to help us choose the audience who will see the post when we publish it on Facebook. ge:
- If we want just publish the post to people on an specific Country, City or Region we can use the Targeting class to specific those filters, and not just that, we can filter people even by age or people interested in specific interests.

I am attaching a couple of  screenshots about how targeting audience works.
Thank You.

<img width="586" alt="screen shot 2016-07-08 at 11 08 11 am" src="https://cloud.githubusercontent.com/assets/2057827/16737496/d78b3120-474e-11e6-83d5-d287d9176156.png">
<img width="504" alt="screen shot 2016-07-11 at 9 54 54 am" src="https://cloud.githubusercontent.com/assets/2057827/16737508/e8413e2e-474e-11e6-9888-8afa6122459d.png">
