### PR TITLE
Refactor likes (int field) in Page.java. Fixes #209

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/LikeOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/LikeOperations.java
@@ -27,7 +27,8 @@ import org.springframework.social.MissingAuthorizationException;
 public interface LikeOperations {
 
 	/**
-	 * Retrieves a list of references to users who have liked the specified object.
+	 * If object ID is an Album, Checkin, Comment, Note, Photo, Post, or Video then retrieves list of references to users who have liked the specified object.
+	 * If object ID is a Page or User then retrieves list of references liked by the specified object.
 	 * Limited to 25 references. 
 	 * Pass the {@link PagingParameters} returned from {@link PagedList#getNextPage()} into {@link #getLikes(String, PagingParameters)} to get the next page.
 	 * @param objectId the object ID (an Album, Checkin, Comment, Note, Photo, Post, or Video).
@@ -38,7 +39,8 @@ public interface LikeOperations {
 	PagedList<Reference> getLikes(String objectId);
 
 	/**
-	 * Retrieves a page of references to users who have liked the specified object.
+	 * If object ID is an Album, Checkin, Comment, Note, Photo, Post, or Video then retrieves list of references to users who have liked the specified object.
+	 * If object ID is a Page or User then retrieves list of references liked by the specified object.
 	 * @param objectId the object ID (an Album, Checkin, Comment, Note, Photo, Post, or Video).
 	 * @param pagingParameters the paging parameters for fetching a specific page of references.
 	 * @return a list of {@link Reference} objects for the users who have liked the object.

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
@@ -125,8 +125,6 @@ public class Page extends FacebookObject {
 	
 	private boolean isVerified;
 	
-	private int likes;
-	
 	private String link;
 
 	private Location location;
@@ -304,14 +302,6 @@ public class Page extends FacebookObject {
 	public String getCompanyOverview() {
 		return companyOverview;
 	}
-	
-	/**
-	 * @return The number of users who like this page. For Global Brand pages, this count is fall all pages across the brand.
-	 */
-	public int getLikes() {
-		return likes;
-	}
-	
 	
 	public int getTalkingAboutCount() {
 		return talkingAboutCount;

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
@@ -125,7 +125,7 @@ public class Page extends FacebookObject {
 	
 	private boolean isVerified;
 
-	private int funCount;
+	private int fanCount;
 	
 	private String link;
 
@@ -308,8 +308,8 @@ public class Page extends FacebookObject {
 	/**
 	 * @return The number of users who like this page. For Global Brand pages, this count is fall all pages across the brand.
 	 */
-	public int getFunCount() {
-		return funCount;
+	public int getFanCount() {
+		return fanCount;
 	}
 
 	

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
@@ -124,6 +124,8 @@ public class Page extends FacebookObject {
 	private boolean isUnclaimed;
 	
 	private boolean isVerified;
+
+	private int funCount;
 	
 	private String link;
 
@@ -302,6 +304,14 @@ public class Page extends FacebookObject {
 	public String getCompanyOverview() {
 		return companyOverview;
 	}
+
+	/**
+	 * @return The number of users who like this page. For Global Brand pages, this count is fall all pages across the brand.
+	 */
+	public int getFunCount() {
+		return funCount;
+	}
+
 	
 	public int getTalkingAboutCount() {
 		return talkingAboutCount;

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
@@ -143,5 +143,5 @@ class LikeTemplate implements LikeOperations {
 		return graphApi.fetchConnections(userId, "games", Page.class, pagingParameters.toMap(), PAGE_FIELDS);
 	}
 
-	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,fun_count,checkins,cover";
+	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,fan_count,checkins,cover";
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
@@ -143,5 +143,5 @@ class LikeTemplate implements LikeOperations {
 		return graphApi.fetchConnections(userId, "games", Page.class, pagingParameters.toMap(), PAGE_FIELDS);
 	}
 
-	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,checkins,cover";
+	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,fun_count,checkins,cover";
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
@@ -143,5 +143,5 @@ class LikeTemplate implements LikeOperations {
 		return graphApi.fetchConnections(userId, "games", Page.class, pagingParameters.toMap(), PAGE_FIELDS);
 	}
 
-	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,likes,checkins,cover";
+	private static final String PAGE_FIELDS = "id,name,category,description,location,website,picture,phone,affiliation,company_overview,checkins,cover";
 }

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
@@ -135,8 +135,8 @@ abstract class PageMixin extends FacebookObjectMixin {
 	@JsonProperty("is_unclaimed")
 	boolean isUnclaimed;
 
-	@JsonProperty("likes")
-	int likes;
+	@JsonProperty("fun_count")
+	int funCount;
 	
 	@JsonProperty("link")
 	String link;

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
@@ -135,8 +135,8 @@ abstract class PageMixin extends FacebookObjectMixin {
 	@JsonProperty("is_unclaimed")
 	boolean isUnclaimed;
 
-	@JsonProperty("fun_count")
-	int funCount;
+	@JsonProperty("fan_count")
+	int fanCount;
 	
 	@JsonProperty("link")
 	String link;

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
@@ -68,7 +68,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked() {
-		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -78,7 +78,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -88,7 +88,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getPagesLiked_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -98,7 +98,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -108,7 +108,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks() {
-		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -118,7 +118,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getBooks_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -128,7 +128,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -138,7 +138,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -148,7 +148,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies() {
-		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -158,7 +158,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -168,7 +168,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -178,7 +178,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -188,7 +188,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMusic() {
-		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -198,7 +198,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -208,7 +208,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -218,7 +218,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -228,7 +228,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision() {
-		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -238,7 +238,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -248,7 +248,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -258,7 +258,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getTelevision_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -268,7 +268,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getGames() {
-		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -278,7 +278,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -288,7 +288,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -298,7 +298,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getGames_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfan_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
@@ -68,7 +68,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked() {
-		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -78,7 +78,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -88,7 +88,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getPagesLiked_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -98,7 +98,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -108,7 +108,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks() {
-		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -118,7 +118,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getBooks_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -128,7 +128,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -138,7 +138,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -148,7 +148,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies() {
-		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -158,7 +158,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -168,7 +168,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -178,7 +178,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -188,7 +188,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMusic() {
-		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -198,7 +198,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -208,7 +208,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -218,7 +218,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -228,7 +228,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision() {
-		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -238,7 +238,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -248,7 +248,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -258,7 +258,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getTelevision_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -268,7 +268,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getGames() {
-		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -278,7 +278,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -288,7 +288,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -298,7 +298,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getGames_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Clikes%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
@@ -68,7 +68,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked() {
-		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -78,7 +78,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -88,7 +88,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getPagesLiked_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -98,7 +98,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getPagesLiked_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/likes?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -108,7 +108,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks() {
-		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -118,7 +118,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getBooks_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -128,7 +128,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -138,7 +138,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getBooks_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/books?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -148,7 +148,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies() {
-		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -158,7 +158,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -168,7 +168,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -178,7 +178,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMovies_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/movies?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -188,7 +188,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getMusic() {
-		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -198,7 +198,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -208,7 +208,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -218,7 +218,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getMusic_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/music?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -228,7 +228,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision() {
-		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -238,7 +238,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -248,7 +248,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getTelevision_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -258,7 +258,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getTelevision_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/television?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("new-user-likes"), MediaType.APPLICATION_JSON));
@@ -268,7 +268,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 		
 	@Test
 	public void getGames() {
-		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -278,7 +278,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("me/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -288,7 +288,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 
 	@Test
 	public void getGames_forSpecificUser() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));
@@ -298,7 +298,7 @@ public class LikeTemplateTest extends AbstractFacebookApiTest {
 	
 	@Test
 	public void getGames_forSpecificUser_withPagingParameters() {
-		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Ccheckins%2Ccover")))
+		mockServer.expect(requestTo(fbUrl("123456789/games?limit=25&offset=50&fields=id%2Cname%2Ccategory%2Cdescription%2Clocation%2Cwebsite%2Cpicture%2Cphone%2Caffiliation%2Ccompany_overview%2Cfun_count%2Ccheckins%2Ccover")))
 			.andExpect(method(GET))
 			.andExpect(header("Authorization", "OAuth someAccessToken"))
 			.andRespond(withSuccess(jsonResource("games"), MediaType.APPLICATION_JSON));

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -45,7 +45,6 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 		assertEquals("220817147947513", page.getId());
 		assertEquals("Denton Square Donuts", page.getName());
 		assertEquals("https://www.facebook.com/DentonSquareDonuts", page.getLink());
-		assertEquals(3078, page.getLikes());
 		assertEquals("Restaurant/cafe", page.getCategory());
 		assertEquals("www.dsdonuts.com", page.getWebsite());
 		assertEquals("Denton", page.getLocation().getCity());

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -45,7 +45,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 		assertEquals("220817147947513", page.getId());
 		assertEquals("Denton Square Donuts", page.getName());
 		assertEquals("https://www.facebook.com/DentonSquareDonuts", page.getLink());
-		assertEquals(3078, page.getFunCount());
+		assertEquals(3078, page.getFanCount());
 		assertEquals("Restaurant/cafe", page.getCategory());
 		assertEquals("www.dsdonuts.com", page.getWebsite());
 		assertEquals("Denton", page.getLocation().getCity());

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -45,6 +45,7 @@ public class PageTemplateTest extends AbstractFacebookApiTest {
 		assertEquals("220817147947513", page.getId());
 		assertEquals("Denton Square Donuts", page.getName());
 		assertEquals("https://www.facebook.com/DentonSquareDonuts", page.getLink());
+		assertEquals(3078, page.getFunCount());
 		assertEquals("Restaurant/cafe", page.getCategory());
 		assertEquals("www.dsdonuts.com", page.getWebsite());
 		assertEquals("Denton", page.getLocation().getCity());

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
@@ -5,24 +5,6 @@
       "name": "U2", 
       "category": "Musician/band", 
       "website": "http://www.u2.com http://www.interscope.com/u2 http://www.myspace.com/u2 http://www.imeem.com/u2music",
-      "likes": {
-        "data": [
-          {
-            "name": "Mulch, Sweat, & Shears",
-            "id": "36643253738"
-          },
-          {
-            "name": "Torchy's Tacos",
-            "id": "188620089283"
-          }
-        ],
-        "paging": {
-          "cursors": {
-            "before": "NzA2MjE2MjQyNzI4NjY5",
-            "after": "MTAzMTA2NDI5NzMwMjQ5"
-          }
-        }
-      },
       "created_time": "2012-08-22T21:48:41+0000", 
       "picture": {
         "data": {
@@ -36,24 +18,6 @@
       "name": "Pirates of the Caribbean", 
       "category": "Movie", 
       "description": "Pirates of the Caribbean is a movie about Captain Jack Sparrow.",
-      "likes": {
-        "data": [
-          {
-            "name": "Mulch, Sweat, & Shears",
-            "id": "36643253738"
-          },
-          {
-            "name": "Torchy's Tacos",
-            "id": "188620089283"
-          }
-        ],
-        "paging": {
-          "cursors": {
-            "before": "NzA2MjE2MjQyNzI4NjY5",
-            "after": "MTAzMTA2NDI5NzMwMjQ5"
-          }
-        }
-      },
       "created_time": "2010-05-18T15:18:49+0000", 
       "picture": {
         "data": {

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
@@ -4,8 +4,25 @@
       "id": "5678046685", 
       "name": "U2", 
       "category": "Musician/band", 
-      "website": "http://www.u2.com http://www.interscope.com/u2 http://www.myspace.com/u2 http://www.imeem.com/u2music", 
-      "likes": 12974013, 
+      "website": "http://www.u2.com http://www.interscope.com/u2 http://www.myspace.com/u2 http://www.imeem.com/u2music",
+      "likes": {
+        "data": [
+          {
+            "name": "Mulch, Sweat, & Shears",
+            "id": "36643253738"
+          },
+          {
+            "name": "Torchy's Tacos",
+            "id": "188620089283"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "NzA2MjE2MjQyNzI4NjY5",
+            "after": "MTAzMTA2NDI5NzMwMjQ5"
+          }
+        }
+      },
       "created_time": "2012-08-22T21:48:41+0000", 
       "picture": {
         "data": {
@@ -18,8 +35,25 @@
       "id": "113294925350820", 
       "name": "Pirates of the Caribbean", 
       "category": "Movie", 
-      "description": "Pirates of the Caribbean is a movie about Captain Jack Sparrow.", 
-      "likes": 2106819, 
+      "description": "Pirates of the Caribbean is a movie about Captain Jack Sparrow.",
+      "likes": {
+        "data": [
+          {
+            "name": "Mulch, Sweat, & Shears",
+            "id": "36643253738"
+          },
+          {
+            "name": "Torchy's Tacos",
+            "id": "188620089283"
+          }
+        ],
+        "paging": {
+          "cursors": {
+            "before": "NzA2MjE2MjQyNzI4NjY5",
+            "after": "MTAzMTA2NDI5NzMwMjQ5"
+          }
+        }
+      },
       "created_time": "2010-05-18T15:18:49+0000", 
       "picture": {
         "data": {
@@ -33,8 +67,7 @@
       "name": "Freebirds World Burrito", 
       "category": "Food/beverages", 
       "description": "We do what's right for the burrito! Be sure to also Follow us on Twitter for deals, fun and more: http://twitter.com/FREEBIRDS_WB  ", 
-      "website": "http://www.freebirds.com/", 
-      "likes": 111599, 
+      "website": "http://www.freebirds.com/",
       "created_time": "2010-03-12T03:24:35+0000", 
       "picture": {
         "data": {

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
@@ -5,7 +5,7 @@
       "name": "U2", 
       "category": "Musician/band", 
       "website": "http://www.u2.com http://www.interscope.com/u2 http://www.myspace.com/u2 http://www.imeem.com/u2music",
-      "fun_count": 12974013,
+      "fan_count": 12974013,
       "created_time": "2012-08-22T21:48:41+0000", 
       "picture": {
         "data": {
@@ -19,7 +19,7 @@
       "name": "Pirates of the Caribbean", 
       "category": "Movie", 
       "description": "Pirates of the Caribbean is a movie about Captain Jack Sparrow.",
-      "fun_count": 2106819,
+      "fan_count": 2106819,
       "created_time": "2010-05-18T15:18:49+0000", 
       "picture": {
         "data": {
@@ -34,7 +34,7 @@
       "category": "Food/beverages", 
       "description": "We do what's right for the burrito! Be sure to also Follow us on Twitter for deals, fun and more: http://twitter.com/FREEBIRDS_WB  ", 
       "website": "http://www.freebirds.com/",
-      "fun_count": 111599,
+      "fan_count": 111599,
       "created_time": "2010-03-12T03:24:35+0000", 
       "picture": {
         "data": {

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/new-user-likes.json
@@ -5,6 +5,7 @@
       "name": "U2", 
       "category": "Musician/band", 
       "website": "http://www.u2.com http://www.interscope.com/u2 http://www.myspace.com/u2 http://www.imeem.com/u2music",
+      "fun_count": 12974013,
       "created_time": "2012-08-22T21:48:41+0000", 
       "picture": {
         "data": {
@@ -18,6 +19,7 @@
       "name": "Pirates of the Caribbean", 
       "category": "Movie", 
       "description": "Pirates of the Caribbean is a movie about Captain Jack Sparrow.",
+      "fun_count": 2106819,
       "created_time": "2010-05-18T15:18:49+0000", 
       "picture": {
         "data": {
@@ -32,6 +34,7 @@
       "category": "Food/beverages", 
       "description": "We do what's right for the burrito! Be sure to also Follow us on Twitter for deals, fun and more: http://twitter.com/FREEBIRDS_WB  ", 
       "website": "http://www.freebirds.com/",
+      "fun_count": 111599,
       "created_time": "2010-03-12T03:24:35+0000", 
       "picture": {
         "data": {

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
@@ -33,7 +33,7 @@
    },
    "is_community_page": false,
    "is_published": true,
-   "fun_count": 3078,
+   "fan_count": 3078,
    "link": "https://www.facebook.com/DentonSquareDonuts",
    "location": {
       "street": "208 W Oak St",

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
@@ -33,7 +33,6 @@
    },
    "is_community_page": false,
    "is_published": true,
-   "likes": 3078,
    "link": "https://www.facebook.com/DentonSquareDonuts",
    "location": {
       "street": "208 W Oak St",

--- a/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
+++ b/spring-social-facebook/src/test/resources/org/springframework/social/facebook/api/place-with-hours-page.json
@@ -33,6 +33,7 @@
    },
    "is_community_page": false,
    "is_published": true,
+   "fun_count": 3078,
    "link": "https://www.facebook.com/DentonSquareDonuts",
    "location": {
       "street": "208 W Oak St",


### PR DESCRIPTION
Remove likes (int field) from Page object as it is no longer supported by facebook api. Fixes #209
