### PR TITLE
Added a field full_picture to the Post Class

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Post.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Post.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,8 @@ public class Post extends FacebookObject {
 	private String objectId;
 	
 	private String picture;
+
+	private String full_picture;
 
 	private Page place;
 	
@@ -152,6 +154,10 @@ public class Post extends FacebookObject {
 	
 	public String getPicture() {
 		return picture;
+	}
+
+	public String getFull_picture() {
+		return full_picture;
 	}
 
 	public Page getPlace() {

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,7 +285,7 @@ class FeedTemplate implements FeedOperations {
 	
 	private static final String[] ALL_POST_FIELDS = {
 			"id", "actions", "admin_creator", "application", "caption", "created_time", "description", "from", "icon",
-			"is_hidden", "is_published", "link", "message", "message_tags", "name", "object_id", "picture", "place", 
+			"is_hidden", "is_published", "link", "message", "message_tags", "name", "object_id", "picture", "full_picture", "place",
 			"privacy", "properties", "source", "status_type", "story", "to", "type", "updated_time", "with_tags", "shares"
 	};
 


### PR DESCRIPTION
This will help when someone needs the original image rather than the default image provided by facebook which cannot be practically used anywhere else due to its size.
I faced this problem as I needed to fetch Posts for my app, where I needed the message and the picture, but the picture returned by the current Post object was of a size that I could not use.
Fetching full sized images using fetchConnections was slowing down the time taken to send the data back to my app as a new request needs to be made for every post.