### PR TITLE
Fix bug where picture wasn't being set in PostData or FacebookLink Fixes #203

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostData.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostData.java
@@ -82,6 +82,7 @@ public class PostData {
 	 */
 	public PostData link(String linkUrl, String picture, String name, String caption, String description) {
 		this.linkUrl = linkUrl;
+		this.picture = picture;
 		this.name = name;
 		this.caption = caption;
 		this.description = description;

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
@@ -172,6 +172,8 @@ class FeedTemplate implements FeedOperations {
 		map.set("caption", link.getCaption());
 		map.set("description", link.getDescription());
 		map.set("message", message);
+		// Intentionally not adding null checks to the above to preserve backwards compatibility
+		if(link.getPicture() != null) map.set("picture", link.getPicture());
 		return graphApi.publish(ownerId, "feed", map);
 	}
 	

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
@@ -258,6 +258,19 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 	}
 
 	@Test
+	public void post_link_with_picture() throws Exception {
+		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World&picture=pictureUrl";
+		mockServer.expect(requestTo(fbUrl("me/feed")))
+				  .andExpect(method(POST))
+				  .andExpect(header("Authorization", "OAuth someAccessToken"))
+				  .andExpect(content().string(requestBody))
+				  .andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
+		FacebookLink link = new FacebookLink("someLink", "some name", "some caption", "some description", "pictureUrl");
+		assertEquals("123456_78901234", facebook.feedOperations().postLink("Hello Facebook World", link));
+		mockServer.verify();
+	}
+
+	@Test
 	public void post_NewPost_messageOnly() throws Exception {
 		String requestBody = "message=Hello+Facebook+World";
 		mockServer.expect(requestTo(fbUrl("123456789/feed")))
@@ -348,6 +361,19 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 				.andExpect(content().string(requestBody))
 				.andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
 		FacebookLink link = new FacebookLink("someLink", "some name", "some caption", "some description");
+		assertEquals("123456_78901234", facebook.feedOperations().postLink("123456789", "Hello Facebook World", link));
+		mockServer.verify();
+	}
+
+	@Test
+	public void post_link_toAnotherFeed_withPicture() throws Exception {
+		String requestBody = "link=someLink&name=some+name&caption=some+caption&description=some+description&message=Hello+Facebook+World&picture=pictureUrl";
+		mockServer.expect(requestTo(fbUrl("123456789/feed")))
+				  .andExpect(method(POST))
+				  .andExpect(header("Authorization", "OAuth someAccessToken"))
+				  .andExpect(content().string(requestBody))
+				  .andRespond(withSuccess("{\"id\":\"123456_78901234\"}", MediaType.APPLICATION_JSON));
+		FacebookLink link = new FacebookLink("someLink", "some name", "some caption", "some description", "pictureUrl");
 		assertEquals("123456_78901234", facebook.feedOperations().postLink("123456789", "Hello Facebook World", link));
 		mockServer.verify();
 	}


### PR DESCRIPTION
Fix 2 bugs related to submitting an override picture as part of a feed link. One in PostData where the constructor param "picture" wasn't being used. And one in FeedTemplate where FacebookLink.getPicture wasn't being added to query params. Fixes #203 
