### PR TITLE
Fixed 'offset' when appending paging params.

### DIFF
--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
@@ -266,6 +266,9 @@ class FeedTemplate implements FeedOperations {
 		if (pagedListParameters.getLimit() != null) {
 			uriBuilder = uriBuilder.queryParam("limit", String.valueOf(pagedListParameters.getLimit()));
 		}
+		if (pagedListParameters.getOffset() != null) {
+			uriBuilder = uriBuilder.queryParam("offset", String.valueOf(pagedListParameters.getOffset()));
+		}
 		if (pagedListParameters.getSince() != null) {
 			uriBuilder = uriBuilder.queryParam("since", String.valueOf(pagedListParameters.getSince()));
 		}

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
@@ -45,6 +45,17 @@ public class FeedTemplateTest extends AbstractFacebookApiTest {
 		assertEquals(5, feed.size());
 		assertFeedEntries(feed);
 	}
+	
+	@Test
+	public void getFeed_withPagedListParameters_offset() {
+		mockServer.expect(requestTo(fbUrl("me/feed?limit=25&offset=10&fields=" + ALL_POST_FIELDS_STR)))
+				.andExpect(method(GET))
+				.andExpect(header("Authorization", "OAuth someAccessToken"))
+			.andRespond(withSuccess(jsonResource("feed"), MediaType.APPLICATION_JSON));
+		List<Post> feed = facebook.feedOperations().getFeed(new PagingParameters(25, 10, null, null));
+		assertEquals(5, feed.size());
+		assertFeedEntries(feed);
+	}
 
 	@Test
 	public void getFeed_withPagedListParameters_since() {


### PR DESCRIPTION
The "offset" attribute from the PagingParameters object  is skipped when building the execution URL for the feed posts (FeedTemplate.java)

