### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/FacebookAutoConfiguration.java
+++ b/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/FacebookAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/FacebookProperties.java
+++ b/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/FacebookProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/package-info.java
+++ b/spring-social-facebook-autoconfigure/src/main/java/org/springframework/social/facebook/autoconfigure/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-autoconfigure/src/test/java/org/springframework/social/facebook/autoconfigure/AbstractSocialAutoConfigurationTests.java
+++ b/spring-social-facebook-autoconfigure/src/test/java/org/springframework/social/facebook/autoconfigure/AbstractSocialAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-autoconfigure/src/test/java/org/springframework/social/facebook/autoconfigure/FacebookAutoConfigurationTests.java
+++ b/spring-social-facebook-autoconfigure/src/test/java/org/springframework/social/facebook/autoconfigure/FacebookAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/AchievementOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/AchievementOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/CommentOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/CommentOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/ErrorsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/ErrorsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/EventOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/EventOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FacebookITest.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FacebookITest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FeedOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FeedOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FriendOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/FriendOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/GroupOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/GroupOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/ITestCredentials.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/ITestCredentials.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/LikeOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/LikeOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/MediaOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/MediaOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/PageOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/PageOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/UserOperationsITests.java
+++ b/spring-social-facebook-itest/src/test/java/org/springframework/social/facebook/itest/UserOperationsITests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/CanvasSignInController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/DisconnectController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/DisconnectController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookCookieParser.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookCookieParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookCookieValue.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookCookieValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookInitTag.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookInitTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookWebArgumentResolver.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/FacebookWebArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/RealTimeUpdate.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/RealTimeUpdate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/RealTimeUpdateController.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/RealTimeUpdateController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequest.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestArgumentResolver.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestDecoder.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestDecoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestException.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/SignedRequestException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/UpdateHandler.java
+++ b/spring-social-facebook-web/src/main/java/org/springframework/social/facebook/web/UpdateHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/DeauthorizationRequest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/DeauthorizationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/DisconnectControllerTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/DisconnectControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/FacebookArgumentResolverTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/FacebookArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/FacebookInitTagTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/FacebookInitTagTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/RealTimeUpdateControllerTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/RealTimeUpdateControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/SignedRequestArgumentResolverTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/SignedRequestArgumentResolverTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/SignedRequestDecoderTest.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/SignedRequestDecoderTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/StubConnectionRepository.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/StubConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/StubUsersConnectionRepository.java
+++ b/spring-social-facebook-web/src/test/java/org/springframework/social/facebook/web/StubUsersConnectionRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Account.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Account.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Achievement.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Achievement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AchievementOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AchievementOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AchievementType.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AchievementType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Action.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Action.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ActionMetadata.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ActionMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AgeRange.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/AgeRange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Album.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Album.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ApplicationReference.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ApplicationReference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/BookActions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/BookActions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Comment.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Comment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CommentOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CommentOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CountedList.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CountedList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CoverPhoto.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/CoverPhoto.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Currency.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Currency.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Device.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Device.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EducationExperience.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EducationExperience.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Engagement.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Engagement.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Event.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Event.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EventInvitee.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EventInvitee.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EventOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/EventOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Experience.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Experience.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Facebook.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Facebook.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookError.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookError.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookErrors.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookErrors.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookLink.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookLink.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookObject.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FacebookObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FamilyMember.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FamilyMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FeedOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FeedOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FitnessActions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FitnessActions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlException.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlResult.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlResultMapper.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FqlResultMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FriendList.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FriendList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FriendOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/FriendOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GeneralActions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GeneralActions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GraphApi.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Group.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Group.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupMemberReference.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupMemberReference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupMembership.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupMembership.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/GroupOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ImageSource.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ImageSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ImageType.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ImageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Invitation.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Invitation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/LikeOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/LikeOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ListAndCount.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ListAndCount.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ListenActionMetadata.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ListenActionMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Location.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Location.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MailingAddress.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MailingAddress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MediaOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MediaOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MessageTag.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MessageTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MissingNamespaceException.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MissingNamespaceException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MusicActions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/MusicActions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/NotAFriendException.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/NotAFriendException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/OpenGraphOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Page.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageAdministrationException.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageAdministrationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageParking.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageParking.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePaymentOptions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePaymentOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePostData.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagePostData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageRestaurantServices.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageRestaurantServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageRestaurantSpecialties.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageRestaurantSpecialties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageUpdate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PageUpdate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagedList.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagedList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagingParameters.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PagingParameters.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PaymentPricePoint.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PaymentPricePoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PaymentPricePoints.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PaymentPricePoints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Permission.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Permission.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Photo.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Photo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Place.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Place.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PlaceTag.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PlaceTag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Post.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Post.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostData.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostData.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostProperty.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/PostProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ProfilePictureSource.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ProfilePictureSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RatingActionMetadata.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RatingActionMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Reference.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ResourceOwnershipException.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/ResourceOwnershipException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RestaurantServices.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RestaurantServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RsvpStatus.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/RsvpStatus.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/SecuritySettings.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/SecuritySettings.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/SocialContextOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/SocialContextOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/StoryAttachment.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/StoryAttachment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Tag.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Tag.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Targeting.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUser.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUserList.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUserList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUserOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/TestUserOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/User.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserIdForApp.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserIdForApp.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserInvitableFriend.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserInvitableFriend.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserTaggableFriend.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/UserTaggableFriend.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Video.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/Video.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoActions.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoActions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoUploadLimits.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VideoUploadLimits.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VoipInfo.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/VoipInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/WatchActionMetadata.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/WatchActionMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/WorkEntry.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/WorkEntry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/AbstractFacebookOperations.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/AbstractFacebookOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/AchievementTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/AchievementTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/BookActionsTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/BookActionsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/CommentTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/CommentTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/EventTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookErrorHandler.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookErrorHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FacebookTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FeedTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FitnessActionsTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FitnessActionsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/FriendTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/GeneralActionsTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/GeneralActionsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/GroupTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/GroupTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/LikeTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/ListDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/ListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/MediaTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/MediaTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/MusicActionsTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/MusicActionsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/OpenGraphTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PageTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PagedListUtils.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/PagedListUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/SocialContextTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/SocialContextTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/TestUserTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/TestUserTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/UserTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/VideoActionsTemplate.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/VideoActionsTemplate.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AccountMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AccountMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AchievementMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AchievementMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AchievementTypeMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AchievementTypeMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ActionMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ActionMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AlbumMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/AlbumMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ApplicationReferenceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ApplicationReferenceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CommentMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CommentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CoverPhotoMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CoverPhotoMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CurrencyMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/CurrencyMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/DeviceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/DeviceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EducationExperienceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EducationExperienceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EngagementMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EngagementMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EventInviteeMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EventInviteeMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EventMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/EventMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ExperienceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ExperienceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FacebookModule.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FacebookModule.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FacebookObjectMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FacebookObjectMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FamilyMemberMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FamilyMemberMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FriendListMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/FriendListMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMemberReferenceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMemberReferenceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMembershipMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMembershipMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/GroupMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ImageSourceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ImageSourceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/InvitationMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/InvitationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/LocationMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/LocationMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MailingAddressMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MailingAddressMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MessageTagMapDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MessageTagMapDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MessageTagMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/MessageTagMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageParkingMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageParkingMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PagePaymentOptionsMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PagePaymentOptionsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageRestaurantServicesMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PageRestaurantServicesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PaymentPricePointMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PaymentPricePointMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PaymentPricePointsMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PaymentPricePointsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PhotoMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PhotoMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PictureDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PictureDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PlaceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PlaceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PlaceTagMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PlaceTagMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PostMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PostMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PostPropertyMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/PostPropertyMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ProfilePictureSourceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ProfilePictureSourceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ReferenceListDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ReferenceListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ReferenceMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/ReferenceMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RestaurantServicesMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RestaurantServicesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RestaurantSpecialtiesMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RestaurantSpecialtiesMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RsvpStatusDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/RsvpStatusDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/SecuritySettingsMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/SecuritySettingsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/StoryAttachmentMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/StoryAttachmentMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TagListDeserializer.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TagListDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TagMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TagMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TestUserMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/TestUserMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserIdForAppMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserIdForAppMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserInvitableFriendMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserInvitableFriendMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserTaggableFriendMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/UserTaggableFriendMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoUploadLimitsMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VideoUploadLimitsMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VoipInfoMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/VoipInfoMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/WorkEntryMixin.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/api/impl/json/WorkEntryMixin.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/support/FacebookApiHelper.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/support/FacebookApiHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/xml/FacebookConfigBeanDefinitionParser.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/xml/FacebookConfigBeanDefinitionParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/xml/FacebookNamespaceHandler.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/config/xml/FacebookNamespaceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookAdapter.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookConnectionFactory.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookConnectionFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/connect/FacebookServiceProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/security/FacebookAppSecretProofInterceptor.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/security/FacebookAppSecretProofInterceptor.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/main/java/org/springframework/social/facebook/security/FacebookAuthenticationService.java
+++ b/spring-social-facebook/src/main/java/org/springframework/social/facebook/security/FacebookAuthenticationService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AbstractFacebookApiTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AbstractFacebookApiTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AchievementTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/AchievementTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/BookActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/BookActionsTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/CommentTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/ErrorHandlingTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/ErrorHandlingTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/EventTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FeedTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FitnessActionTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FitnessActionTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/FriendTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GeneralActionTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GeneralActionTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GroupTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/GroupTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/LikeTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MediaTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MusicActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/MusicActionsTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/OpenGraphTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/OpenGraphTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PageTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PagedListTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/PagedListTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/SocialContextTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/SocialContextTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/TestUserTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/TestUserTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/UserTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/UserTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VersionedApiTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VersionedApiTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VideoActionsTemplateTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/api/VideoActionsTemplateTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-social-facebook/src/test/java/org/springframework/social/facebook/connect/FacebookAdapterTest.java
+++ b/spring-social-facebook/src/test/java/org/springframework/social/facebook/connect/FacebookAdapterTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/dist/license.txt
+++ b/src/dist/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 2 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 255 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).