### PR TITLE
URL Cleanup

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.11-bin.zip

--- a/spring-social-facebook-itest/build.gradle
+++ b/spring-social-facebook-itest/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'java'
 
 buildscript {
     repositories {
-        mavenCentral()
+        maven { url 'https://repo.maven.apache.org/maven2/' }
     }
 
     dependencies {
@@ -26,7 +26,7 @@ repositories {
 	maven { url 'https://maven.springframework.org/milestone' }
 	maven { url 'https://maven.springframework.org/snapshot' }
 	maven { url 'https://download.java.net/maven/2' }
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.